### PR TITLE
refactor(shared): unify AnalysisResult + deduplicate helpers

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -105,7 +105,7 @@ analysis_platform/                    https://github.com/JG-CSI-Velocity/analysi
     platform_app/     4,271 LOC  Orchestrator, Typer CLI, Streamlit UI
   tests/
     shared/           50 tests
-    ars/              545 collected (13 fail to collect -- pydantic_settings dep)
+    ars/              545 tests (collection failures resolved)
     txn/              597 tests
     ics/              1,049 tests (incl. referral: 212)
     platform/         60 tests
@@ -119,7 +119,7 @@ analysis_platform/                    https://github.com/JG-CSI-Velocity/analysi
 | Source LOC | 44,708 |
 | Test LOC | 21,854 |
 | Total tests collected | 2,318 |
-| Tests passing | 2,305 (13 ARS pre-existing collection failures) |
+| Tests passing | 2,318 |
 | Coverage | 89% (16,018 stmts, 1,737 missed) |
 | CI floor | 80% (`--cov-fail-under=80`) |
 | Test time | ~2 min |
@@ -136,7 +136,7 @@ None. All merged.
 
 | # | Title | Notes |
 |---|-------|-------|
-| 14 | Platform App: Wire Pipeline Execution | Tier 4.1 -- biggest remaining feature. BLOCKS on Tier 3.1 (unified AnalysisResult). |
+| 14 | Platform App: Wire Pipeline Execution | **CLOSED** -- implementation already complete in run_analysis.py |
 
 **txn-analysis (standalone -- superseded, commented for migration):**
 

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/__init__.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/__init__.py
@@ -237,10 +237,10 @@ def run_all_analyses(
         except Exception as e:
             logger.warning("  [%d/%d] %s FAILED: %s", i + 1, total, name, e)
             results.append(
-                AnalysisResult(
-                    name=name,
-                    title=name,
-                    df=pd.DataFrame(),
+                AnalysisResult.from_df(
+                    name,
+                    name,
+                    pd.DataFrame(),
                     error=str(e),
                 )
             )
@@ -263,10 +263,10 @@ def run_all_analyses(
     except Exception as e:
         logger.warning("  [%d/%d] %s FAILED: %s", total + 1, total + 1, name, e)
         results.append(
-            AnalysisResult(
-                name=name,
-                title=name,
-                df=pd.DataFrame(),
+            AnalysisResult.from_df(
+                name,
+                name,
+                pd.DataFrame(),
                 error=str(e),
             )
         )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/activity.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/activity.py
@@ -58,10 +58,10 @@ def analyze_activity_summary(
 
     result_df = kpi_summary(metrics)
 
-    return AnalysisResult(
-        name="Activity Summary",
-        title="ICS Stat O Debit - L12M Activity KPIs",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Activity Summary",
+        "ICS Stat O Debit - L12M Activity KPIs",
+        result_df,
         sheet_name="22_Activity_KPIs",
     )
 
@@ -87,10 +87,10 @@ def analyze_activity_by_debit_source(
                 "Avg Spend",
             ]
         )
-        return AnalysisResult(
-            name="Activity by Debit+Source",
-            title="ICS Stat O - Activity by Source",
-            df=result_df,
+        return AnalysisResult.from_df(
+            "Activity by Debit+Source",
+            "ICS Stat O - Activity by Source",
+            result_df,
             sheet_name="23_Activity_Source",
         )
 
@@ -124,10 +124,10 @@ def analyze_activity_by_debit_source(
 
     result_df = append_grand_total_row(result_df, label_col="Source")
 
-    return AnalysisResult(
-        name="Activity by Debit+Source",
-        title="ICS Stat O - Activity by Source",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Activity by Debit+Source",
+        "ICS Stat O - Activity by Source",
+        result_df,
         sheet_name="23_Activity_Source",
     )
 
@@ -153,10 +153,10 @@ def analyze_activity_by_balance(
                 "Avg Swipes",
             ]
         )
-        return AnalysisResult(
-            name="Activity by Balance",
-            title="ICS Stat O Debit - Activity by Balance Tier",
-            df=result_df,
+        return AnalysisResult.from_df(
+            "Activity by Balance",
+            "ICS Stat O Debit - Activity by Balance Tier",
+            result_df,
             sheet_name="24_Activity_Bal",
         )
 
@@ -183,10 +183,10 @@ def analyze_activity_by_balance(
         ["Balance Tier", "Count", "Active Count", "Activation Rate", "Avg Swipes"]
     ].reset_index(drop=True)
 
-    return AnalysisResult(
-        name="Activity by Balance",
-        title="ICS Stat O Debit - Activity by Balance Tier",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Activity by Balance",
+        "ICS Stat O Debit - Activity by Balance Tier",
+        result_df,
         sheet_name="24_Activity_Bal",
     )
 
@@ -212,10 +212,10 @@ def analyze_activity_by_branch(
                 "Avg Spend",
             ]
         )
-        return AnalysisResult(
-            name="Activity by Branch",
-            title="ICS Stat O Debit - Activity by Branch",
-            df=result_df,
+        return AnalysisResult.from_df(
+            "Activity by Branch",
+            "ICS Stat O Debit - Activity by Branch",
+            result_df,
             sheet_name="25_Activity_Branch",
         )
 
@@ -249,10 +249,10 @@ def analyze_activity_by_branch(
 
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="Activity by Branch",
-        title="ICS Stat O Debit - Activity by Branch",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Activity by Branch",
+        "ICS Stat O Debit - Activity by Branch",
+        result_df,
         sheet_name="25_Activity_Branch",
     )
 
@@ -294,10 +294,10 @@ def analyze_monthly_trends(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Monthly Trends",
-        title="ICS Stat O Debit - Monthly Activity Trends",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Monthly Trends",
+        "ICS Stat O Debit - Monthly Activity Trends",
+        result_df,
         sheet_name="26_Monthly_Trends",
     )
 
@@ -361,10 +361,10 @@ def analyze_activity_by_source_comparison(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Activity by Source Comparison",
-        title="L12M Activity KPIs - DM vs Referral",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Activity by Source Comparison",
+        "L12M Activity KPIs - DM vs Referral",
+        result_df,
         sheet_name="63_Activity_DM_Ref",
     )
 
@@ -406,10 +406,10 @@ def analyze_monthly_interchange(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Monthly Interchange Trend",
-        title="ICS Monthly Interchange Revenue Trend",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Monthly Interchange Trend",
+        "ICS Monthly Interchange Revenue Trend",
+        result_df,
         sheet_name="71_Monthly_Interchange",
     )
 
@@ -423,10 +423,10 @@ def analyze_business_vs_personal(
 ) -> AnalysisResult:
     """ax72: Activity KPIs comparing Business vs Personal accounts."""
     if "Business?" not in ics_stat_o_debit.columns:
-        return AnalysisResult(
-            name="Business vs Personal",
-            title="Business vs Personal Card Activity",
-            df=kpi_summary([("Status", "No Business? column in data")]),
+        return AnalysisResult.from_df(
+            "Business vs Personal",
+            "Business vs Personal Card Activity",
+            kpi_summary([("Status", "No Business? column in data")]),
             sheet_name="72_Biz_vs_Personal",
         )
 
@@ -449,9 +449,9 @@ def analyze_business_vs_personal(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Business vs Personal",
-        title="Business vs Personal Card Activity",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Business vs Personal",
+        "Business vs Personal Card Activity",
+        result_df,
         sheet_name="72_Biz_vs_Personal",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/base.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/base.py
@@ -1,36 +1,10 @@
-"""Base analysis infrastructure: AnalysisResult dataclass and helpers."""
+"""Base analysis infrastructure: AnalysisResult dataclass and helpers.
 
-from dataclasses import dataclass, field
-from typing import Any
+All canonical types and helpers live in the ``shared`` package.
+Re-exported here so existing ICS code needs zero import changes.
+"""
 
-import pandas as pd
+from shared.helpers import safe_percentage, safe_ratio
+from shared.types import AnalysisResult
 
-
-@dataclass
-class AnalysisResult:
-    """Result of a single analysis."""
-
-    name: str
-    title: str
-    df: pd.DataFrame
-    error: str | None = None
-    sheet_name: str = ""
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-    def __post_init__(self):
-        if not self.sheet_name:
-            self.sheet_name = self.name.replace(" ", "_")[:31]
-
-
-def safe_percentage(numerator: float, denominator: float) -> float:
-    """Compute percentage with zero-division guard. Returns 0-100."""
-    if denominator == 0 or pd.isna(denominator):
-        return 0.0
-    return round((numerator / denominator) * 100, 2)
-
-
-def safe_ratio(numerator: float, denominator: float, decimals: int = 2) -> float:
-    """Compute ratio with zero-division guard."""
-    if denominator == 0 or pd.isna(denominator):
-        return 0.0
-    return round(numerator / denominator, decimals)
+__all__ = ["AnalysisResult", "safe_percentage", "safe_ratio"]

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/cohort.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/cohort.py
@@ -76,10 +76,10 @@ def analyze_cohort_activation(
             "M12 Active",
             "M12 Activation %",
         ]
-        return AnalysisResult(
-            name="Cohort Activation",
-            title="ICS Stat O Debit - Cohort Activation",
-            df=pd.DataFrame(columns=cols),
+        return AnalysisResult.from_df(
+            "Cohort Activation",
+            "ICS Stat O Debit - Cohort Activation",
+            pd.DataFrame(columns=cols),
             sheet_name="27_Cohort_Activ",
         )
 
@@ -115,10 +115,10 @@ def analyze_cohort_activation(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Cohort Activation",
-        title="ICS Stat O Debit - Cohort Activation",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Cohort Activation",
+        "ICS Stat O Debit - Cohort Activation",
+        result_df,
         sheet_name="27_Cohort_Activ",
     )
 
@@ -140,10 +140,10 @@ def analyze_cohort_heatmap(
 
     if data.empty:
         cols = ["Opening Month"] + settings.last_12_months
-        return AnalysisResult(
-            name="Cohort Heatmap",
-            title="ICS Stat O Debit - Cohort Heatmap",
-            df=pd.DataFrame(columns=cols),
+        return AnalysisResult.from_df(
+            "Cohort Heatmap",
+            "ICS Stat O Debit - Cohort Heatmap",
+            pd.DataFrame(columns=cols),
             sheet_name="28_Cohort_Heatmap",
         )
 
@@ -171,9 +171,9 @@ def analyze_cohort_heatmap(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Cohort Heatmap",
-        title="ICS Stat O Debit - Cohort Heatmap",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Cohort Heatmap",
+        "ICS Stat O Debit - Cohort Heatmap",
+        result_df,
         sheet_name="28_Cohort_Heatmap",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/cohort_detail.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/cohort_detail.py
@@ -42,10 +42,10 @@ def analyze_cohort_milestones(
 
     if data.empty:
         cols = ["Opening Month", "Cohort Size", "Avg Bal"] + milestone_cols
-        return AnalysisResult(
-            name="Cohort Milestones",
-            title="ICS Stat O Debit - Cohort Milestones",
-            df=pd.DataFrame(columns=cols),
+        return AnalysisResult.from_df(
+            "Cohort Milestones",
+            "ICS Stat O Debit - Cohort Milestones",
+            pd.DataFrame(columns=cols),
             sheet_name="29_Cohort_Miles",
         )
 
@@ -91,10 +91,10 @@ def analyze_cohort_milestones(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Cohort Milestones",
-        title="ICS Stat O Debit - Cohort Milestones",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Cohort Milestones",
+        "ICS Stat O Debit - Cohort Milestones",
+        result_df,
         sheet_name="29_Cohort_Miles",
     )
 
@@ -121,10 +121,10 @@ def analyze_activation_summary(
             ("M6 Activation Rate", None),
             ("M12 Activation Rate", None),
         ]
-        return AnalysisResult(
-            name="Activation Summary",
-            title="ICS Stat O Debit - Activation Summary",
-            df=kpi_summary(metrics),
+        return AnalysisResult.from_df(
+            "Activation Summary",
+            "ICS Stat O Debit - Activation Summary",
+            kpi_summary(metrics),
             sheet_name="31_Activ_Summary",
         )
 
@@ -153,10 +153,10 @@ def analyze_activation_summary(
 
     result_df = kpi_summary(metrics)
 
-    return AnalysisResult(
-        name="Activation Summary",
-        title="ICS Stat O Debit - Activation Summary",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Activation Summary",
+        "ICS Stat O Debit - Activation Summary",
+        result_df,
         sheet_name="31_Activ_Summary",
     )
 
@@ -189,10 +189,10 @@ def analyze_growth_patterns(
     ]
 
     if data.empty:
-        return AnalysisResult(
-            name="Growth Patterns",
-            title="ICS Stat O Debit - Growth Patterns",
-            df=pd.DataFrame(columns=growth_cols),
+        return AnalysisResult.from_df(
+            "Growth Patterns",
+            "ICS Stat O Debit - Growth Patterns",
+            pd.DataFrame(columns=growth_cols),
             sheet_name="32_Growth",
         )
 
@@ -232,10 +232,10 @@ def analyze_growth_patterns(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Growth Patterns",
-        title="ICS Stat O Debit - Growth Patterns",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Growth Patterns",
+        "ICS Stat O Debit - Growth Patterns",
+        result_df,
         sheet_name="32_Growth",
     )
 
@@ -264,10 +264,10 @@ def analyze_activation_personas(
     ]
 
     if data.empty:
-        return AnalysisResult(
-            name="Activation Personas",
-            title="ICS Stat O Debit - Activation Personas",
-            df=pd.DataFrame(columns=persona_cols),
+        return AnalysisResult.from_df(
+            "Activation Personas",
+            "ICS Stat O Debit - Activation Personas",
+            pd.DataFrame(columns=persona_cols),
             sheet_name="34_Personas",
         )
 
@@ -317,10 +317,10 @@ def analyze_activation_personas(
             )
 
     if not categorized:
-        return AnalysisResult(
-            name="Activation Personas",
-            title="ICS Stat O Debit - Activation Personas",
-            df=pd.DataFrame(columns=persona_cols),
+        return AnalysisResult.from_df(
+            "Activation Personas",
+            "ICS Stat O Debit - Activation Personas",
+            pd.DataFrame(columns=persona_cols),
             sheet_name="34_Personas",
         )
 
@@ -349,10 +349,10 @@ def analyze_activation_personas(
     summary = summary.sort_values("Category").reset_index(drop=True)
     summary["Category"] = summary["Category"].astype(str)
 
-    return AnalysisResult(
-        name="Activation Personas",
-        title="ICS Stat O Debit - Activation Personas",
-        df=summary,
+    return AnalysisResult.from_df(
+        "Activation Personas",
+        "ICS Stat O Debit - Activation Personas",
+        summary,
         sheet_name="34_Personas",
     )
 
@@ -381,10 +381,10 @@ def analyze_branch_activation(
                 "Activation Rate",
             ]
         )
-        return AnalysisResult(
-            name="Branch Activation",
-            title="ICS Stat O Debit - Branch Activation",
-            df=result_df,
+        return AnalysisResult.from_df(
+            "Branch Activation",
+            "ICS Stat O Debit - Branch Activation",
+            result_df,
             sheet_name="36_Branch_Activ",
         )
 
@@ -411,9 +411,9 @@ def analyze_branch_activation(
 
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="Branch Activation",
-        title="ICS Stat O Debit - Branch Activation",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Branch Activation",
+        "ICS Stat O Debit - Branch Activation",
+        result_df,
         sheet_name="36_Branch_Activ",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/demographics.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/demographics.py
@@ -35,10 +35,10 @@ def analyze_age_comparison(
         pct_of=["Count"],
     )
 
-    return AnalysisResult(
-        name="Age Comparison",
-        title="ICS Stat Code O - Account Age Distribution",
-        df=result,
+    return AnalysisResult.from_df(
+        "Age Comparison",
+        "ICS Stat Code O - Account Age Distribution",
+        result,
         sheet_name="14_Age_Comparison",
     )
 
@@ -69,10 +69,10 @@ def analyze_closures(
 
     result = append_grand_total_row(result, label_col="Month Closed")
 
-    return AnalysisResult(
-        name="Closures",
-        title="ICS Accounts - Closures by Month",
-        df=result,
+    return AnalysisResult.from_df(
+        "Closures",
+        "ICS Accounts - Closures by Month",
+        result,
         sheet_name="15_Closures",
     )
 
@@ -99,10 +99,10 @@ def analyze_open_vs_close(
 
     result = kpi_summary(metrics)
 
-    return AnalysisResult(
-        name="Open vs Close",
-        title="ICS Accounts - Open vs Closed",
-        df=result,
+    return AnalysisResult.from_df(
+        "Open vs Close",
+        "ICS Accounts - Open vs Closed",
+        result,
         sheet_name="16_Open_vs_Close",
     )
 
@@ -125,10 +125,10 @@ def analyze_balance_tiers(
         pct_of=["Count"],
     )
 
-    return AnalysisResult(
-        name="Balance Tiers",
-        title="ICS Stat Code O - Balance Tier Distribution",
-        df=result,
+    return AnalysisResult.from_df(
+        "Balance Tiers",
+        "ICS Stat Code O - Balance Tier Distribution",
+        result,
         sheet_name="17_Balance_Tiers",
     )
 
@@ -154,10 +154,10 @@ def analyze_stat_open_close(
     result["Avg Curr Bal"] = result["Avg Curr Bal"].round(2)
     result = append_grand_total_row(result, label_col="Stat Code")
 
-    return AnalysisResult(
-        name="Stat Open Close",
-        title="ICS Accounts - Open/Close by Stat Code",
-        df=result,
+    return AnalysisResult.from_df(
+        "Stat Open Close",
+        "ICS Accounts - Open/Close by Stat Code",
+        result,
         sheet_name="18_Stat_Open_Close",
     )
 
@@ -187,10 +187,10 @@ def analyze_age_vs_balance(
 
     result["Avg Curr Bal"] = result["Avg Curr Bal"].round(2)
 
-    return AnalysisResult(
-        name="Age vs Balance",
-        title="ICS Stat Code O - Age vs Average Balance",
-        df=result,
+    return AnalysisResult.from_df(
+        "Age vs Balance",
+        "ICS Stat Code O - Age vs Average Balance",
+        result,
         sheet_name="19_Age_vs_Balance",
     )
 
@@ -228,10 +228,10 @@ def analyze_balance_tier_detail(
     result["Avg Swipes"] = result["Avg Swipes"].round(1)
     result["Avg Spend"] = result["Avg Spend"].round(2)
 
-    return AnalysisResult(
-        name="Balance Tier Detail",
-        title="ICS Stat Code O Debit - Balance Tier Detail",
-        df=result,
+    return AnalysisResult.from_df(
+        "Balance Tier Detail",
+        "ICS Stat Code O Debit - Balance Tier Detail",
+        result,
         sheet_name="20_Bal_Tier_Detail",
     )
 
@@ -257,10 +257,10 @@ def analyze_age_dist(
         pct_of=["Count"],
     )
 
-    return AnalysisResult(
-        name="Age Distribution",
-        title="ICS Stat Code O - Age Distribution",
-        df=result,
+    return AnalysisResult.from_df(
+        "Age Distribution",
+        "ICS Stat Code O - Age Distribution",
+        result,
         sheet_name="21_Age_Dist",
     )
 
@@ -277,10 +277,10 @@ def analyze_balance_trajectory(
     Shows whether accounts are growing or draining balances.
     """
     if "Avg Bal" not in ics_stat_o.columns:
-        return AnalysisResult(
-            name="Balance Trajectory",
-            title="ICS Balance Trajectory (Avg Bal vs Curr Bal)",
-            df=kpi_summary([("Status", "No Avg Bal column in data")]),
+        return AnalysisResult.from_df(
+            "Balance Trajectory",
+            "ICS Balance Trajectory (Avg Bal vs Curr Bal)",
+            kpi_summary([("Status", "No Avg Bal column in data")]),
             sheet_name="83_Bal_Trajectory",
         )
 
@@ -319,9 +319,9 @@ def analyze_balance_trajectory(
 
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="Balance Trajectory",
-        title="ICS Balance Trajectory (Avg Bal vs Curr Bal)",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Balance Trajectory",
+        "ICS Balance Trajectory (Avg Bal vs Curr Bal)",
+        result_df,
         sheet_name="83_Bal_Trajectory",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/dm_source.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/dm_source.py
@@ -55,10 +55,10 @@ def analyze_dm_overview(
         ("Total L12M Spend", total_spend),
     ]
 
-    return AnalysisResult(
-        name="DM Overview",
-        title="Direct Mail Source - Overview KPIs",
-        df=kpi_summary(metrics),
+    return AnalysisResult.from_df(
+        "DM Overview",
+        "Direct Mail Source - Overview KPIs",
+        kpi_summary(metrics),
         sheet_name="45_DM_Overview",
     )
 
@@ -74,10 +74,10 @@ def analyze_dm_by_branch(
     data = _dm_filter(ics_stat_o)
 
     if data.empty:
-        return AnalysisResult(
-            name="DM by Branch",
-            title="DM Open Accounts by Branch",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "DM by Branch",
+            "DM Open Accounts by Branch",
+            pd.DataFrame(
                 columns=["Branch", "Count", "% of DM", "Debit Count", "Debit %", "Avg Balance"]
             ),
             sheet_name="46_DM_Branch",
@@ -109,10 +109,10 @@ def analyze_dm_by_branch(
 
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="DM by Branch",
-        title="DM Open Accounts by Branch",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "DM by Branch",
+        "DM Open Accounts by Branch",
+        result_df,
         sheet_name="46_DM_Branch",
     )
 
@@ -129,10 +129,10 @@ def analyze_dm_by_debit(
     data = add_l12m_activity(data, settings.last_12_months)
 
     if data.empty:
-        return AnalysisResult(
-            name="DM by Debit Status",
-            title="DM Open Accounts by Debit Status",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "DM by Debit Status",
+            "DM Open Accounts by Debit Status",
+            pd.DataFrame(
                 columns=[
                     "Debit?",
                     "Count",
@@ -184,10 +184,10 @@ def analyze_dm_by_debit(
 
     result_df = append_grand_total_row(result_df, label_col="Debit?")
 
-    return AnalysisResult(
-        name="DM by Debit Status",
-        title="DM Open Accounts by Debit Status",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "DM by Debit Status",
+        "DM Open Accounts by Debit Status",
+        result_df,
         sheet_name="47_DM_Debit",
     )
 
@@ -203,10 +203,10 @@ def analyze_dm_by_product(
     data = _dm_filter(ics_stat_o)
 
     if data.empty:
-        return AnalysisResult(
-            name="DM by Product",
-            title="DM Open Accounts by Product Code",
-            df=pd.DataFrame(columns=["Prod Code", "Count", "%", "Debit Count", "Debit %"]),
+        return AnalysisResult.from_df(
+            "DM by Product",
+            "DM Open Accounts by Product Code",
+            pd.DataFrame(columns=["Prod Code", "Count", "%", "Debit Count", "Debit %"]),
             sheet_name="48_DM_Product",
         )
 
@@ -234,10 +234,10 @@ def analyze_dm_by_product(
 
     result_df = append_grand_total_row(result_df, label_col="Prod Code")
 
-    return AnalysisResult(
-        name="DM by Product",
-        title="DM Open Accounts by Product Code",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "DM by Product",
+        "DM Open Accounts by Product Code",
+        result_df,
         sheet_name="48_DM_Product",
     )
 
@@ -253,10 +253,10 @@ def analyze_dm_by_year(
     data = _dm_filter(ics_stat_o)
 
     if data.empty:
-        return AnalysisResult(
-            name="DM by Year Opened",
-            title="DM Open Accounts by Year Opened",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "DM by Year Opened",
+            "DM Open Accounts by Year Opened",
+            pd.DataFrame(
                 columns=["Year Opened", "Count", "%", "Debit Count", "Debit %", "Avg Balance"]
             ),
             sheet_name="49_DM_Year",
@@ -293,10 +293,10 @@ def analyze_dm_by_year(
 
     result_df = append_grand_total_row(result_df, label_col="Year Opened")
 
-    return AnalysisResult(
-        name="DM by Year Opened",
-        title="DM Open Accounts by Year Opened",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "DM by Year Opened",
+        "DM Open Accounts by Year Opened",
+        result_df,
         sheet_name="49_DM_Year",
     )
 
@@ -342,10 +342,10 @@ def analyze_dm_activity(
         ),
     ]
 
-    return AnalysisResult(
-        name="DM Activity Summary",
-        title="DM Debit Accounts - L12M Activity KPIs",
-        df=kpi_summary(metrics),
+    return AnalysisResult.from_df(
+        "DM Activity Summary",
+        "DM Debit Accounts - L12M Activity KPIs",
+        kpi_summary(metrics),
         sheet_name="50_DM_Activity",
     )
 
@@ -362,10 +362,10 @@ def analyze_dm_activity_by_branch(
     data = add_l12m_activity(data, settings.last_12_months)
 
     if data.empty:
-        return AnalysisResult(
-            name="DM Activity by Branch",
-            title="DM Debit Accounts - Activity by Branch",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "DM Activity by Branch",
+            "DM Debit Accounts - Activity by Branch",
+            pd.DataFrame(
                 columns=[
                     "Branch",
                     "Count",
@@ -408,10 +408,10 @@ def analyze_dm_activity_by_branch(
 
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="DM Activity by Branch",
-        title="DM Debit Accounts - Activity by Branch",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "DM Activity by Branch",
+        "DM Debit Accounts - Activity by Branch",
+        result_df,
         sheet_name="51_DM_Act_Branch",
     )
 
@@ -451,9 +451,9 @@ def analyze_dm_monthly_trends(
             }
         )
 
-    return AnalysisResult(
-        name="DM Monthly Trends",
-        title="DM Debit Accounts - Monthly Activity Trends",
-        df=pd.DataFrame(rows),
+    return AnalysisResult.from_df(
+        "DM Monthly Trends",
+        "DM Debit Accounts - Monthly Activity Trends",
+        pd.DataFrame(rows),
         sheet_name="52_DM_Monthly",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/executive_summary.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/executive_summary.py
@@ -288,10 +288,10 @@ def analyze_executive_summary(
         debit_count=debit_count,
     )
 
-    return AnalysisResult(
-        name="Executive Summary",
-        title="Executive Summary - Key ICS Metrics",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Executive Summary",
+        "Executive Summary - Key ICS Metrics",
+        result_df,
         sheet_name="99_Exec_Summary",
         metadata={
             "hero_kpis": hero_kpis,

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/performance.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/performance.py
@@ -19,19 +19,19 @@ def analyze_days_to_first_use(
     data = ics_stat_o_debit.copy()
 
     if "Date Opened" not in data.columns or data.empty:
-        return AnalysisResult(
-            name="Days to First Use",
-            title="ICS Days to First Use",
-            df=pd.DataFrame(columns=["Days Bucket", "Count", "% of Total"]),
+        return AnalysisResult.from_df(
+            "Days to First Use",
+            "ICS Days to First Use",
+            pd.DataFrame(columns=["Days Bucket", "Count", "% of Total"]),
             sheet_name="43_Days_First_Use",
         )
 
     tags = settings.last_12_months
     if not tags:
-        return AnalysisResult(
-            name="Days to First Use",
-            title="ICS Days to First Use",
-            df=pd.DataFrame(columns=["Days Bucket", "Count", "% of Total"]),
+        return AnalysisResult.from_df(
+            "Days to First Use",
+            "ICS Days to First Use",
+            pd.DataFrame(columns=["Days Bucket", "Count", "% of Total"]),
             sheet_name="43_Days_First_Use",
         )
 
@@ -106,10 +106,10 @@ def analyze_days_to_first_use(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Days to First Use",
-        title="ICS Days to First Use",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Days to First Use",
+        "ICS Days to First Use",
+        result_df,
         sheet_name="43_Days_First_Use",
     )
 
@@ -126,10 +126,10 @@ def analyze_branch_performance_index(
 
     cols_needed = ["Branch", "Active in L12M", "Total L12M Swipes", "Total L12M Spend", "Curr Bal"]
     if data.empty or not all(c in data.columns for c in cols_needed):
-        return AnalysisResult(
-            name="Branch Performance Index",
-            title="ICS Branch Performance Index",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "Branch Performance Index",
+            "ICS Branch Performance Index",
+            pd.DataFrame(
                 columns=[
                     "Branch",
                     "Accounts",
@@ -198,10 +198,10 @@ def analyze_branch_performance_index(
         .reset_index(drop=True)
     )
 
-    return AnalysisResult(
-        name="Branch Performance Index",
-        title="ICS Branch Performance Index",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Branch Performance Index",
+        "ICS Branch Performance Index",
+        result_df,
         sheet_name="44_Branch_Perf",
     )
 
@@ -217,10 +217,10 @@ def analyze_product_code_performance(
     data = add_l12m_activity(ics_stat_o_debit.copy(), settings.last_12_months)
 
     if data.empty or "Prod Code" not in data.columns:
-        return AnalysisResult(
-            name="Product Code Performance",
-            title="ICS Product Code Performance",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "Product Code Performance",
+            "ICS Product Code Performance",
+            pd.DataFrame(
                 columns=[
                     "Prod Code",
                     "Accounts",
@@ -276,9 +276,9 @@ def analyze_product_code_performance(
 
     result_df = append_grand_total_row(result_df, label_col="Prod Code")
 
-    return AnalysisResult(
-        name="Product Code Performance",
-        title="ICS Product Code Performance",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Product Code Performance",
+        "ICS Product Code Performance",
+        result_df,
         sheet_name="81_Prod_Perf",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/persona.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/persona.py
@@ -142,10 +142,10 @@ def analyze_persona_overview(
     ]
 
     if classified.empty:
-        return AnalysisResult(
-            name="Persona Overview",
-            title="Debit Activation Persona Overview",
-            df=pd.DataFrame(columns=cols),
+        return AnalysisResult.from_df(
+            "Persona Overview",
+            "Debit Activation Persona Overview",
+            pd.DataFrame(columns=cols),
             sheet_name="55_Persona_Overview",
         )
 
@@ -192,10 +192,10 @@ def analyze_persona_overview(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Persona Overview",
-        title="Debit Activation Persona Overview",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Persona Overview",
+        "Debit Activation Persona Overview",
+        result_df,
         sheet_name="55_Persona_Overview",
     )
 
@@ -225,10 +225,10 @@ def analyze_persona_contribution(
     ]
 
     if classified.empty:
-        return AnalysisResult(
-            name="Persona Swipe Contribution",
-            title="Swipe Contribution by Persona",
-            df=pd.DataFrame(columns=cols),
+        return AnalysisResult.from_df(
+            "Persona Swipe Contribution",
+            "Swipe Contribution by Persona",
+            pd.DataFrame(columns=cols),
             sheet_name="56_Persona_Contrib",
         )
 
@@ -264,10 +264,10 @@ def analyze_persona_contribution(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Persona Swipe Contribution",
-        title="Swipe Contribution by Persona",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Persona Swipe Contribution",
+        "Swipe Contribution by Persona",
+        result_df,
         sheet_name="56_Persona_Contrib",
     )
 
@@ -290,20 +290,20 @@ def analyze_persona_by_branch(
     pivot_cols = ["Branch"] + PERSONA_ORDER + ["Total", "Fast Activator %"]
 
     if classified.empty or "Branch" not in classified.columns:
-        return AnalysisResult(
-            name="Persona by Branch",
-            title="Persona Distribution by Branch",
-            df=pd.DataFrame(columns=pivot_cols),
+        return AnalysisResult.from_df(
+            "Persona by Branch",
+            "Persona Distribution by Branch",
+            pd.DataFrame(columns=pivot_cols),
             sheet_name="57_Persona_Branch",
         )
 
     result_df = _persona_pivot(classified, "Branch")
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="Persona by Branch",
-        title="Persona Distribution by Branch",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Persona by Branch",
+        "Persona Distribution by Branch",
+        result_df,
         sheet_name="57_Persona_Branch",
     )
 
@@ -326,20 +326,20 @@ def analyze_persona_by_source(
     pivot_cols = ["Source"] + PERSONA_ORDER + ["Total", "Fast Activator %"]
 
     if classified.empty or "Source" not in classified.columns:
-        return AnalysisResult(
-            name="Persona by Source",
-            title="Persona Distribution by Source",
-            df=pd.DataFrame(columns=pivot_cols),
+        return AnalysisResult.from_df(
+            "Persona by Source",
+            "Persona Distribution by Source",
+            pd.DataFrame(columns=pivot_cols),
             sheet_name="58_Persona_Source",
         )
 
     result_df = _persona_pivot(classified, "Source")
     result_df = append_grand_total_row(result_df, label_col="Source")
 
-    return AnalysisResult(
-        name="Persona by Source",
-        title="Persona Distribution by Source",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Persona by Source",
+        "Persona Distribution by Source",
+        result_df,
         sheet_name="58_Persona_Source",
     )
 
@@ -360,10 +360,10 @@ def analyze_persona_revenue(
     classified = _classify_accounts(ics_stat_o_debit, settings)
 
     if classified.empty or "Total L12M Spend" not in classified.columns:
-        return AnalysisResult(
-            name="Persona Revenue Impact",
-            title="Persona Revenue Impact",
-            df=kpi_summary([("No data", 0)]),
+        return AnalysisResult.from_df(
+            "Persona Revenue Impact",
+            "Persona Revenue Impact",
+            kpi_summary([("No data", 0)]),
             sheet_name="59_Persona_Revenue",
         )
 
@@ -400,10 +400,10 @@ def analyze_persona_revenue(
         ("Revenue Lift (25% Never -> Slow)", round(revenue_lift, 2)),
     ]
 
-    return AnalysisResult(
-        name="Persona Revenue Impact",
-        title="Persona Revenue Impact",
-        df=kpi_summary(metrics),
+    return AnalysisResult.from_df(
+        "Persona Revenue Impact",
+        "Persona Revenue Impact",
+        kpi_summary(metrics),
         sheet_name="59_Persona_Revenue",
     )
 
@@ -426,20 +426,20 @@ def analyze_persona_by_balance(
     pivot_cols = ["Balance Tier"] + PERSONA_ORDER + ["Total", "Fast Activator %"]
 
     if classified.empty or "Curr Bal" not in classified.columns:
-        return AnalysisResult(
-            name="Persona by Balance Tier",
-            title="Persona Distribution by Balance Tier",
-            df=pd.DataFrame(columns=pivot_cols),
+        return AnalysisResult.from_df(
+            "Persona by Balance Tier",
+            "Persona Distribution by Balance Tier",
+            pd.DataFrame(columns=pivot_cols),
             sheet_name="60_Persona_Balance",
         )
 
     classified = add_balance_tier(classified, settings)
 
     if "Balance Tier" not in classified.columns:
-        return AnalysisResult(
-            name="Persona by Balance Tier",
-            title="Persona Distribution by Balance Tier",
-            df=pd.DataFrame(columns=pivot_cols),
+        return AnalysisResult.from_df(
+            "Persona by Balance Tier",
+            "Persona Distribution by Balance Tier",
+            pd.DataFrame(columns=pivot_cols),
             sheet_name="60_Persona_Balance",
         )
 
@@ -448,10 +448,10 @@ def analyze_persona_by_balance(
     result_df = _persona_pivot(classified, "Balance Tier")
     result_df = append_grand_total_row(result_df, label_col="Balance Tier")
 
-    return AnalysisResult(
-        name="Persona by Balance Tier",
-        title="Persona Distribution by Balance Tier",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Persona by Balance Tier",
+        "Persona Distribution by Balance Tier",
+        result_df,
         sheet_name="60_Persona_Balance",
     )
 
@@ -474,10 +474,10 @@ def analyze_persona_velocity(
     cols = ["Persona", "Days Bucket", "Count", "% of Persona"]
 
     if classified.empty or "Date Opened" not in classified.columns:
-        return AnalysisResult(
-            name="Persona Velocity",
-            title="Activation Velocity by Persona",
-            df=pd.DataFrame(columns=cols),
+        return AnalysisResult.from_df(
+            "Persona Velocity",
+            "Activation Velocity by Persona",
+            pd.DataFrame(columns=cols),
             sheet_name="61_Persona_Velocity",
         )
 
@@ -562,10 +562,10 @@ def analyze_persona_velocity(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Persona Velocity",
-        title="Activation Velocity by Persona",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Persona Velocity",
+        "Activation Velocity by Persona",
+        result_df,
         sheet_name="61_Persona_Velocity",
     )
 
@@ -588,10 +588,10 @@ def analyze_persona_cohort_trend(
     cols = ["Opening Month"] + [f"{p} %" for p in PERSONA_ORDER] + ["Total"]
 
     if classified.empty or "Opening Month" not in classified.columns:
-        return AnalysisResult(
-            name="Persona Cohort Trend",
-            title="Persona Trend by Opening Cohort",
-            df=pd.DataFrame(columns=cols),
+        return AnalysisResult.from_df(
+            "Persona Cohort Trend",
+            "Persona Trend by Opening Cohort",
+            pd.DataFrame(columns=cols),
             sheet_name="62_Persona_Cohort",
         )
 
@@ -613,9 +613,9 @@ def analyze_persona_cohort_trend(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Persona Cohort Trend",
-        title="Persona Trend by Opening Cohort",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Persona Cohort Trend",
+        "Persona Trend by Opening Cohort",
+        result_df,
         sheet_name="62_Persona_Cohort",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/portfolio.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/portfolio.py
@@ -18,10 +18,10 @@ def analyze_engagement_decay(
     """Accounts active in first half of L12M but inactive in second half."""
     tags = settings.last_12_months
     if len(tags) < 4:
-        return AnalysisResult(
-            name="Engagement Decay",
-            title="ICS Engagement Decay Analysis",
-            df=kpi_summary([("Status", "Insufficient L12M data")]),
+        return AnalysisResult.from_df(
+            "Engagement Decay",
+            "ICS Engagement Decay Analysis",
+            kpi_summary([("Status", "Insufficient L12M data")]),
             sheet_name="40_Engagement_Decay",
         )
 
@@ -66,10 +66,10 @@ def analyze_engagement_decay(
     summary = summary.sort_values("Decay Category").reset_index(drop=True)
     summary["Decay Category"] = summary["Decay Category"].astype(str)
 
-    return AnalysisResult(
-        name="Engagement Decay",
-        title="ICS Engagement Decay Analysis",
-        df=summary,
+    return AnalysisResult.from_df(
+        "Engagement Decay",
+        "ICS Engagement Decay Analysis",
+        summary,
         sheet_name="40_Engagement_Decay",
     )
 
@@ -85,10 +85,10 @@ def analyze_net_portfolio_growth(
     data = ics_all.copy()
 
     if "Date Opened" not in data.columns:
-        return AnalysisResult(
-            name="Net Portfolio Growth",
-            title="ICS Net Portfolio Growth",
-            df=pd.DataFrame(columns=["Month", "Opens", "Closes", "Net", "Cumulative"]),
+        return AnalysisResult.from_df(
+            "Net Portfolio Growth",
+            "ICS Net Portfolio Growth",
+            pd.DataFrame(columns=["Month", "Opens", "Closes", "Net", "Cumulative"]),
             sheet_name="41_Net_Growth",
         )
 
@@ -133,10 +133,10 @@ def analyze_net_portfolio_growth(
     result["Net"] = result["Opens"] - result["Closes"]
     result["Cumulative"] = result["Net"].cumsum()
 
-    return AnalysisResult(
-        name="Net Portfolio Growth",
-        title="ICS Net Portfolio Growth",
-        df=result,
+    return AnalysisResult.from_df(
+        "Net Portfolio Growth",
+        "ICS Net Portfolio Growth",
+        result,
         sheet_name="41_Net_Growth",
     )
 
@@ -152,19 +152,19 @@ def analyze_concentration(
     data = add_l12m_activity(ics_stat_o_debit.copy(), settings.last_12_months)
 
     if "Total L12M Spend" not in data.columns or data.empty:
-        return AnalysisResult(
-            name="Spend Concentration",
-            title="ICS Spend Concentration",
-            df=pd.DataFrame(columns=["Percentile", "Account Count", "Spend Share %"]),
+        return AnalysisResult.from_df(
+            "Spend Concentration",
+            "ICS Spend Concentration",
+            pd.DataFrame(columns=["Percentile", "Account Count", "Spend Share %"]),
             sheet_name="42_Concentration",
         )
 
     total_spend = data["Total L12M Spend"].sum()
     if total_spend == 0:
-        return AnalysisResult(
-            name="Spend Concentration",
-            title="ICS Spend Concentration",
-            df=pd.DataFrame(columns=["Percentile", "Account Count", "Spend Share %"]),
+        return AnalysisResult.from_df(
+            "Spend Concentration",
+            "ICS Spend Concentration",
+            pd.DataFrame(columns=["Percentile", "Account Count", "Spend Share %"]),
             sheet_name="42_Concentration",
         )
 
@@ -187,10 +187,10 @@ def analyze_concentration(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Spend Concentration",
-        title="ICS Spend Concentration",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Spend Concentration",
+        "ICS Spend Concentration",
+        result_df,
         sheet_name="42_Concentration",
     )
 
@@ -217,10 +217,10 @@ def analyze_closure_by_source(
     closed = ics_all[ics_all["Stat Code"].isin(settings.closed_stat_codes)].copy()
 
     if closed.empty or "Source" not in closed.columns:
-        return AnalysisResult(
-            name="Closure by Source",
-            title="ICS Closures by Source Channel",
-            df=pd.DataFrame(columns=["Source", "Closed Count", "% of Closures"]),
+        return AnalysisResult.from_df(
+            "Closure by Source",
+            "ICS Closures by Source Channel",
+            pd.DataFrame(columns=["Source", "Closed Count", "% of Closures"]),
             sheet_name="67_Closure_Source",
         )
 
@@ -233,10 +233,10 @@ def analyze_closure_by_source(
     result_df = grouped.sort_values("Closed Count", ascending=False).reset_index(drop=True)
     result_df = append_grand_total_row(result_df, label_col="Source")
 
-    return AnalysisResult(
-        name="Closure by Source",
-        title="ICS Closures by Source Channel",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Closure by Source",
+        "ICS Closures by Source Channel",
+        result_df,
         sheet_name="67_Closure_Source",
     )
 
@@ -252,10 +252,10 @@ def analyze_closure_by_branch(
     closed = ics_all[ics_all["Stat Code"].isin(settings.closed_stat_codes)].copy()
 
     if closed.empty or "Branch" not in closed.columns:
-        return AnalysisResult(
-            name="Closure by Branch",
-            title="ICS Closures by Branch",
-            df=pd.DataFrame(columns=["Branch", "Closed Count", "% of Closures"]),
+        return AnalysisResult.from_df(
+            "Closure by Branch",
+            "ICS Closures by Branch",
+            pd.DataFrame(columns=["Branch", "Closed Count", "% of Closures"]),
             sheet_name="68_Closure_Branch",
         )
 
@@ -268,10 +268,10 @@ def analyze_closure_by_branch(
     result_df = grouped.sort_values("Closed Count", ascending=False).reset_index(drop=True)
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="Closure by Branch",
-        title="ICS Closures by Branch",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Closure by Branch",
+        "ICS Closures by Branch",
+        result_df,
         sheet_name="68_Closure_Branch",
     )
 
@@ -287,10 +287,10 @@ def analyze_closure_by_account_age(
     closed = ics_all[ics_all["Stat Code"].isin(settings.closed_stat_codes)].copy()
 
     if closed.empty or "Date Opened" not in closed.columns:
-        return AnalysisResult(
-            name="Closure by Account Age",
-            title="ICS Closures by Account Age at Closure",
-            df=pd.DataFrame(columns=["Age Range", "Closed Count", "% of Closures"]),
+        return AnalysisResult.from_df(
+            "Closure by Account Age",
+            "ICS Closures by Account Age at Closure",
+            pd.DataFrame(columns=["Age Range", "Closed Count", "% of Closures"]),
             sheet_name="69_Closure_Age",
         )
 
@@ -309,10 +309,10 @@ def analyze_closure_by_account_age(
     closed = add_age_range(closed, settings)
 
     if "Age Range" not in closed.columns:
-        return AnalysisResult(
-            name="Closure by Account Age",
-            title="ICS Closures by Account Age at Closure",
-            df=pd.DataFrame(columns=["Age Range", "Closed Count", "% of Closures"]),
+        return AnalysisResult.from_df(
+            "Closure by Account Age",
+            "ICS Closures by Account Age at Closure",
+            pd.DataFrame(columns=["Age Range", "Closed Count", "% of Closures"]),
             sheet_name="69_Closure_Age",
         )
 
@@ -323,10 +323,10 @@ def analyze_closure_by_account_age(
         lambda x: safe_percentage(x, total_closed)
     )
 
-    return AnalysisResult(
-        name="Closure by Account Age",
-        title="ICS Closures by Account Age at Closure",
-        df=grouped,
+    return AnalysisResult.from_df(
+        "Closure by Account Age",
+        "ICS Closures by Account Age at Closure",
+        grouped,
         sheet_name="69_Closure_Age",
     )
 
@@ -342,10 +342,10 @@ def analyze_net_growth_by_source(
     data = ics_all.copy()
 
     if "Date Opened" not in data.columns or "Source" not in data.columns:
-        return AnalysisResult(
-            name="Net Growth by Source",
-            title="ICS Net Portfolio Growth by Source",
-            df=pd.DataFrame(columns=["Source", "Opens", "Closes", "Net"]),
+        return AnalysisResult.from_df(
+            "Net Growth by Source",
+            "ICS Net Portfolio Growth by Source",
+            pd.DataFrame(columns=["Source", "Opens", "Closes", "Net"]),
             sheet_name="70_Net_Growth_Source",
         )
 
@@ -382,10 +382,10 @@ def analyze_net_growth_by_source(
     result_df = result_df.sort_values("Net", ascending=False).reset_index(drop=True)
     result_df = append_grand_total_row(result_df, label_col="Source")
 
-    return AnalysisResult(
-        name="Net Growth by Source",
-        title="ICS Net Portfolio Growth by Source",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Net Growth by Source",
+        "ICS Net Portfolio Growth by Source",
+        result_df,
         sheet_name="70_Net_Growth_Source",
     )
 
@@ -399,19 +399,19 @@ def analyze_closure_rate_trend(
 ) -> AnalysisResult:
     """ax82: Monthly closure rate trend -- closures per month as % of portfolio."""
     if "Date Closed" not in ics_all.columns:
-        return AnalysisResult(
-            name="Closure Rate Trend",
-            title="ICS Monthly Closure Rate Trend",
-            df=pd.DataFrame(columns=["Month", "Closures", "Portfolio Size", "Closure Rate %"]),
+        return AnalysisResult.from_df(
+            "Closure Rate Trend",
+            "ICS Monthly Closure Rate Trend",
+            pd.DataFrame(columns=["Month", "Closures", "Portfolio Size", "Closure Rate %"]),
             sheet_name="82_Closure_Rate",
         )
 
     closed = ics_all[ics_all["Stat Code"].isin(settings.closed_stat_codes)].copy()
     if closed.empty or closed["Date Closed"].isna().all():
-        return AnalysisResult(
-            name="Closure Rate Trend",
-            title="ICS Monthly Closure Rate Trend",
-            df=pd.DataFrame(columns=["Month", "Closures", "Portfolio Size", "Closure Rate %"]),
+        return AnalysisResult.from_df(
+            "Closure Rate Trend",
+            "ICS Monthly Closure Rate Trend",
+            pd.DataFrame(columns=["Month", "Closures", "Portfolio Size", "Closure Rate %"]),
             sheet_name="82_Closure_Rate",
         )
 
@@ -436,9 +436,9 @@ def analyze_closure_rate_trend(
         columns={"Close Month": "Month"}
     )
 
-    return AnalysisResult(
-        name="Closure Rate Trend",
-        title="ICS Monthly Closure Rate Trend",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Closure Rate Trend",
+        "ICS Monthly Closure Rate Trend",
+        result_df,
         sheet_name="82_Closure_Rate",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/ref_source.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/ref_source.py
@@ -55,10 +55,10 @@ def analyze_ref_overview(
         ("Total L12M Spend", total_spend),
     ]
 
-    return AnalysisResult(
-        name="REF Overview",
-        title="Referral Source - Overview KPIs",
-        df=kpi_summary(metrics),
+    return AnalysisResult.from_df(
+        "REF Overview",
+        "Referral Source - Overview KPIs",
+        kpi_summary(metrics),
         sheet_name="73_REF_Overview",
     )
 
@@ -74,10 +74,10 @@ def analyze_ref_by_branch(
     data = _ref_filter(ics_stat_o)
 
     if data.empty:
-        return AnalysisResult(
-            name="REF by Branch",
-            title="REF Open Accounts by Branch",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "REF by Branch",
+            "REF Open Accounts by Branch",
+            pd.DataFrame(
                 columns=["Branch", "Count", "% of REF", "Debit Count", "Debit %", "Avg Balance"]
             ),
             sheet_name="74_REF_Branch",
@@ -109,10 +109,10 @@ def analyze_ref_by_branch(
 
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="REF by Branch",
-        title="REF Open Accounts by Branch",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "REF by Branch",
+        "REF Open Accounts by Branch",
+        result_df,
         sheet_name="74_REF_Branch",
     )
 
@@ -129,10 +129,10 @@ def analyze_ref_by_debit(
     data = add_l12m_activity(data, settings.last_12_months)
 
     if data.empty:
-        return AnalysisResult(
-            name="REF by Debit Status",
-            title="REF Open Accounts by Debit Status",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "REF by Debit Status",
+            "REF Open Accounts by Debit Status",
+            pd.DataFrame(
                 columns=[
                     "Debit?",
                     "Count",
@@ -183,10 +183,10 @@ def analyze_ref_by_debit(
     result_df = grouped[debit_cols].reset_index(drop=True)
     result_df = append_grand_total_row(result_df, label_col="Debit?")
 
-    return AnalysisResult(
-        name="REF by Debit Status",
-        title="REF Open Accounts by Debit Status",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "REF by Debit Status",
+        "REF Open Accounts by Debit Status",
+        result_df,
         sheet_name="75_REF_Debit",
     )
 
@@ -202,10 +202,10 @@ def analyze_ref_by_product(
     data = _ref_filter(ics_stat_o)
 
     if data.empty:
-        return AnalysisResult(
-            name="REF by Product",
-            title="REF Open Accounts by Product Code",
-            df=pd.DataFrame(columns=["Prod Code", "Count", "%", "Debit Count", "Debit %"]),
+        return AnalysisResult.from_df(
+            "REF by Product",
+            "REF Open Accounts by Product Code",
+            pd.DataFrame(columns=["Prod Code", "Count", "%", "Debit Count", "Debit %"]),
             sheet_name="76_REF_Product",
         )
 
@@ -233,10 +233,10 @@ def analyze_ref_by_product(
 
     result_df = append_grand_total_row(result_df, label_col="Prod Code")
 
-    return AnalysisResult(
-        name="REF by Product",
-        title="REF Open Accounts by Product Code",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "REF by Product",
+        "REF Open Accounts by Product Code",
+        result_df,
         sheet_name="76_REF_Product",
     )
 
@@ -252,10 +252,10 @@ def analyze_ref_by_year(
     data = _ref_filter(ics_stat_o)
 
     if data.empty:
-        return AnalysisResult(
-            name="REF by Year Opened",
-            title="REF Open Accounts by Year Opened",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "REF by Year Opened",
+            "REF Open Accounts by Year Opened",
+            pd.DataFrame(
                 columns=["Year Opened", "Count", "%", "Debit Count", "Debit %", "Avg Balance"]
             ),
             sheet_name="77_REF_Year",
@@ -292,10 +292,10 @@ def analyze_ref_by_year(
 
     result_df = append_grand_total_row(result_df, label_col="Year Opened")
 
-    return AnalysisResult(
-        name="REF by Year Opened",
-        title="REF Open Accounts by Year Opened",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "REF by Year Opened",
+        "REF Open Accounts by Year Opened",
+        result_df,
         sheet_name="77_REF_Year",
     )
 
@@ -341,10 +341,10 @@ def analyze_ref_activity(
         ),
     ]
 
-    return AnalysisResult(
-        name="REF Activity Summary",
-        title="REF Debit Accounts - L12M Activity KPIs",
-        df=kpi_summary(metrics),
+    return AnalysisResult.from_df(
+        "REF Activity Summary",
+        "REF Debit Accounts - L12M Activity KPIs",
+        kpi_summary(metrics),
         sheet_name="78_REF_Activity",
     )
 
@@ -361,10 +361,10 @@ def analyze_ref_activity_by_branch(
     data = add_l12m_activity(data, settings.last_12_months)
 
     if data.empty:
-        return AnalysisResult(
-            name="REF Activity by Branch",
-            title="REF Debit Accounts - Activity by Branch",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "REF Activity by Branch",
+            "REF Debit Accounts - Activity by Branch",
+            pd.DataFrame(
                 columns=[
                     "Branch",
                     "Count",
@@ -407,10 +407,10 @@ def analyze_ref_activity_by_branch(
 
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="REF Activity by Branch",
-        title="REF Debit Accounts - Activity by Branch",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "REF Activity by Branch",
+        "REF Debit Accounts - Activity by Branch",
+        result_df,
         sheet_name="79_REF_Act_Branch",
     )
 
@@ -450,9 +450,9 @@ def analyze_ref_monthly_trends(
             }
         )
 
-    return AnalysisResult(
-        name="REF Monthly Trends",
-        title="REF Debit Accounts - Monthly Activity Trends",
-        df=pd.DataFrame(rows),
+    return AnalysisResult.from_df(
+        "REF Monthly Trends",
+        "REF Debit Accounts - Monthly Activity Trends",
+        pd.DataFrame(rows),
         sheet_name="80_REF_Monthly",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/source.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/source.py
@@ -28,10 +28,10 @@ def analyze_source_dist(
 
     result = append_grand_total_row(result, label_col="Source")
 
-    return AnalysisResult(
-        name="Source Distribution",
-        title="ICS Accounts - Source Distribution",
-        df=result,
+    return AnalysisResult.from_df(
+        "Source Distribution",
+        "ICS Accounts - Source Distribution",
+        result,
         sheet_name="08_Source_Dist",
     )
 
@@ -51,10 +51,10 @@ def analyze_source_by_stat(
         add_totals=True,
     )
 
-    return AnalysisResult(
-        name="Source x Stat Code",
-        title="ICS Accounts - Source by Stat Code",
-        df=result,
+    return AnalysisResult.from_df(
+        "Source x Stat Code",
+        "ICS Accounts - Source by Stat Code",
+        result,
         sheet_name="09_Source_x_Stat",
     )
 
@@ -74,10 +74,10 @@ def analyze_source_by_prod(
         add_totals=True,
     )
 
-    return AnalysisResult(
-        name="Source x Prod Code",
-        title="ICS Stat Code O - Source by Product Code",
-        df=result,
+    return AnalysisResult.from_df(
+        "Source x Prod Code",
+        "ICS Stat Code O - Source by Product Code",
+        result,
         sheet_name="10_Source_x_Prod",
     )
 
@@ -97,10 +97,10 @@ def analyze_source_by_branch(
         add_totals=True,
     )
 
-    return AnalysisResult(
-        name="Source x Branch",
-        title="ICS Stat Code O - Source by Branch",
-        df=result,
+    return AnalysisResult.from_df(
+        "Source x Branch",
+        "ICS Stat Code O - Source by Branch",
+        result,
         sheet_name="11_Source_x_Branch",
     )
 
@@ -123,10 +123,10 @@ def analyze_account_type(
 
     result = append_grand_total_row(result, label_col="Business?")
 
-    return AnalysisResult(
-        name="Account Type",
-        title="ICS Stat Code O - Account Type Distribution",
-        df=result,
+    return AnalysisResult.from_df(
+        "Account Type",
+        "ICS Stat Code O - Account Type Distribution",
+        result,
         sheet_name="12_Account_Type",
     )
 
@@ -153,10 +153,10 @@ def analyze_source_by_year(
         add_totals=True,
     )
 
-    return AnalysisResult(
-        name="Source by Year",
-        title="ICS Stat Code O - Source by Year Opened",
-        df=result,
+    return AnalysisResult.from_df(
+        "Source by Year",
+        "ICS Stat Code O - Source by Year Opened",
+        result,
         sheet_name="13_Source_x_Year",
     )
 
@@ -172,10 +172,10 @@ def analyze_source_acquisition_mix(
     data = ics_all.copy()
 
     if "Date Opened" not in data.columns:
-        return AnalysisResult(
-            name="Source Acquisition Mix",
-            title="ICS Source Acquisition Mix Over Time",
-            df=pd.DataFrame(columns=["Month"]),
+        return AnalysisResult.from_df(
+            "Source Acquisition Mix",
+            "ICS Source Acquisition Mix Over Time",
+            pd.DataFrame(columns=["Month"]),
             sheet_name="85_Source_Acq_Mix",
         )
 
@@ -183,10 +183,10 @@ def analyze_source_acquisition_mix(
     data = data.dropna(subset=["Open Month"])
 
     if data.empty:
-        return AnalysisResult(
-            name="Source Acquisition Mix",
-            title="ICS Source Acquisition Mix Over Time",
-            df=pd.DataFrame(columns=["Month"]),
+        return AnalysisResult.from_df(
+            "Source Acquisition Mix",
+            "ICS Source Acquisition Mix Over Time",
+            pd.DataFrame(columns=["Month"]),
             sheet_name="85_Source_Acq_Mix",
         )
 
@@ -197,9 +197,9 @@ def analyze_source_acquisition_mix(
     ct["Open Month"] = ct["Open Month"].astype(str)
     ct = ct.rename(columns={"Open Month": "Month"})
 
-    return AnalysisResult(
-        name="Source Acquisition Mix",
-        title="ICS Source Acquisition Mix Over Time",
-        df=ct,
+    return AnalysisResult.from_df(
+        "Source Acquisition Mix",
+        "ICS Source Acquisition Mix Over Time",
+        ct,
         sheet_name="85_Source_Acq_Mix",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/strategic.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/strategic.py
@@ -50,10 +50,10 @@ def analyze_activation_funnel(
 
     result_df = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="Activation Funnel",
-        title="ICS Activation Funnel",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Activation Funnel",
+        "ICS Activation Funnel",
+        result_df,
         sheet_name="38_Activ_Funnel",
     )
 
@@ -99,10 +99,10 @@ def analyze_revenue_impact(
 
     result_df = kpi_summary(metrics)
 
-    return AnalysisResult(
-        name="Revenue Impact",
-        title="ICS Revenue Impact Analysis",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Revenue Impact",
+        "ICS Revenue Impact Analysis",
+        result_df,
         sheet_name="39_Revenue_Impact",
     )
 
@@ -119,10 +119,10 @@ def analyze_revenue_by_branch(
     interchange_rate = settings.interchange_rate
 
     if data.empty or "Branch" not in data.columns:
-        return AnalysisResult(
-            name="Revenue by Branch",
-            title="Estimated Interchange Revenue by Branch",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "Revenue by Branch",
+            "Estimated Interchange Revenue by Branch",
+            pd.DataFrame(
                 columns=["Branch", "Accounts", "Total L12M Spend", "Est. Interchange", "Avg Spend"]
             ),
             sheet_name="65_Revenue_Branch",
@@ -151,10 +151,10 @@ def analyze_revenue_by_branch(
 
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="Revenue by Branch",
-        title="Estimated Interchange Revenue by Branch",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Revenue by Branch",
+        "Estimated Interchange Revenue by Branch",
+        result_df,
         sheet_name="65_Revenue_Branch",
     )
 
@@ -171,10 +171,10 @@ def analyze_revenue_by_source(
     interchange_rate = settings.interchange_rate
 
     if data.empty or "Source" not in data.columns:
-        return AnalysisResult(
-            name="Revenue by Source",
-            title="Estimated Interchange Revenue by Source",
-            df=pd.DataFrame(
+        return AnalysisResult.from_df(
+            "Revenue by Source",
+            "Estimated Interchange Revenue by Source",
+            pd.DataFrame(
                 columns=["Source", "Accounts", "Total L12M Spend", "Est. Interchange", "Avg Spend"]
             ),
             sheet_name="66_Revenue_Source",
@@ -203,10 +203,10 @@ def analyze_revenue_by_source(
 
     result_df = append_grand_total_row(result_df, label_col="Source")
 
-    return AnalysisResult(
-        name="Revenue by Source",
-        title="Estimated Interchange Revenue by Source",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "Revenue by Source",
+        "Estimated Interchange Revenue by Source",
+        result_df,
         sheet_name="66_Revenue_Source",
     )
 
@@ -223,10 +223,10 @@ def analyze_dormant_high_balance(
     threshold = 10000
 
     if data.empty:
-        return AnalysisResult(
-            name="Dormant High-Balance",
-            title="Dormant High-Balance Accounts",
-            df=kpi_summary([("Status", "No debit accounts")]),
+        return AnalysisResult.from_df(
+            "Dormant High-Balance",
+            "Dormant High-Balance Accounts",
+            kpi_summary([("Status", "No debit accounts")]),
             sheet_name="84_Dormant_HiBal",
         )
 
@@ -255,9 +255,9 @@ def analyze_dormant_high_balance(
         ("Est. Interchange if Activated", potential_interchange),
     ]
 
-    return AnalysisResult(
-        name="Dormant High-Balance",
-        title="Dormant High-Balance Accounts",
-        df=kpi_summary(metrics),
+    return AnalysisResult.from_df(
+        "Dormant High-Balance",
+        "Dormant High-Balance Accounts",
+        kpi_summary(metrics),
         sheet_name="84_Dormant_HiBal",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/summary.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/analyses/summary.py
@@ -31,10 +31,10 @@ def analyze_total_ics(
         }
     )
 
-    return AnalysisResult(
-        name="Total ICS Accounts",
-        title="ICS Accounts - Total Dataset",
-        df=result,
+    return AnalysisResult.from_df(
+        "Total ICS Accounts",
+        "ICS Accounts - Total Dataset",
+        result,
         sheet_name="01_Total_ICS",
     )
 
@@ -64,10 +64,10 @@ def analyze_open_ics(
         }
     )
 
-    return AnalysisResult(
-        name="Open ICS Accounts",
-        title="ICS Accounts - Open Accounts",
-        df=result,
+    return AnalysisResult.from_df(
+        "Open ICS Accounts",
+        "ICS Accounts - Open Accounts",
+        result,
         sheet_name="02_Open_ICS",
     )
 
@@ -102,10 +102,10 @@ def analyze_stat_code(
 
     result = append_grand_total_row(result, label_col="Stat Code")
 
-    return AnalysisResult(
-        name="ICS by Stat Code",
-        title="ICS Accounts - Status Code Distribution",
-        df=result,
+    return AnalysisResult.from_df(
+        "ICS by Stat Code",
+        "ICS Accounts - Status Code Distribution",
+        result,
         sheet_name="03_Stat_Code",
     )
 
@@ -127,10 +127,10 @@ def analyze_prod_code(
 
     result = append_grand_total_row(result, label_col="Prod Code")
 
-    return AnalysisResult(
-        name="Product Code Distribution",
-        title="ICS Stat Code O - Product Code Distribution",
-        df=result,
+    return AnalysisResult.from_df(
+        "Product Code Distribution",
+        "ICS Stat Code O - Product Code Distribution",
+        result,
         sheet_name="04_Prod_Code",
     )
 
@@ -153,10 +153,10 @@ def analyze_debit_dist(
 
     result = append_grand_total_row(result, label_col="Debit?")
 
-    return AnalysisResult(
-        name="Debit Distribution",
-        title="ICS Stat Code O - Debit Card Distribution",
-        df=result,
+    return AnalysisResult.from_df(
+        "Debit Distribution",
+        "ICS Stat Code O - Debit Card Distribution",
+        result,
         sheet_name="05_Debit_Dist",
     )
 
@@ -178,10 +178,10 @@ def analyze_debit_by_prod(
         rate_numerator="Yes",
     )
 
-    return AnalysisResult(
-        name="Debit x Prod Code",
-        title="ICS Stat Code O - Debit by Product Code",
-        df=result,
+    return AnalysisResult.from_df(
+        "Debit x Prod Code",
+        "ICS Stat Code O - Debit by Product Code",
+        result,
         sheet_name="06_Debit_x_Prod",
     )
 
@@ -203,10 +203,10 @@ def analyze_debit_by_branch(
         rate_numerator="Yes",
     )
 
-    return AnalysisResult(
-        name="Debit x Branch",
-        title="ICS Stat Code O - Debit by Branch",
-        df=result,
+    return AnalysisResult.from_df(
+        "Debit x Branch",
+        "ICS Stat Code O - Debit by Branch",
+        result,
         sheet_name="07_Debit_x_Branch",
     )
 
@@ -220,10 +220,10 @@ def analyze_penetration_by_branch(
 ) -> AnalysisResult:
     """ax64: ICS penetration rate by branch (ICS accounts / total accounts)."""
     if "Branch" not in df.columns:
-        return AnalysisResult(
-            name="ICS Penetration by Branch",
-            title="ICS Penetration by Branch",
-            df=pd.DataFrame(columns=["Branch", "Total Accounts", "ICS Accounts", "Penetration %"]),
+        return AnalysisResult.from_df(
+            "ICS Penetration by Branch",
+            "ICS Penetration by Branch",
+            pd.DataFrame(columns=["Branch", "Total Accounts", "ICS Accounts", "Penetration %"]),
             sheet_name="64_Penetration_Branch",
         )
 
@@ -239,9 +239,9 @@ def analyze_penetration_by_branch(
     result_df = result_df.sort_values("Total Accounts", ascending=False).reset_index(drop=True)
     result_df = append_grand_total_row(result_df, label_col="Branch")
 
-    return AnalysisResult(
-        name="ICS Penetration by Branch",
-        title="ICS Penetration Rate by Branch",
-        df=result_df,
+    return AnalysisResult.from_df(
+        "ICS Penetration by Branch",
+        "ICS Penetration Rate by Branch",
+        result_df,
         sheet_name="64_Penetration_Branch",
     )

--- a/packages/ics_toolkit/src/ics_toolkit/referral/analyses/__init__.py
+++ b/packages/ics_toolkit/src/ics_toolkit/referral/analyses/__init__.py
@@ -55,10 +55,10 @@ def run_all_referral_analyses(
         except Exception as e:
             logger.warning("  [%d/%d] %s FAILED: %s", i + 1, total, name, e)
             results.append(
-                AnalysisResult(
-                    name=name,
-                    title=name,
-                    df=pd.DataFrame(),
+                AnalysisResult.from_df(
+                    name,
+                    name,
+                    pd.DataFrame(),
                     error=str(e),
                 )
             )
@@ -74,10 +74,10 @@ def run_all_referral_analyses(
     except Exception as e:
         logger.warning("  [%d/%d] %s FAILED: %s", total + 1, total + 1, name, e)
         results.append(
-            AnalysisResult(
-                name=name,
-                title=name,
-                df=pd.DataFrame(),
+            AnalysisResult.from_df(
+                name,
+                name,
+                pd.DataFrame(),
                 error=str(e),
             )
         )

--- a/packages/ics_toolkit/src/ics_toolkit/referral/analyses/branch_density.py
+++ b/packages/ics_toolkit/src/ics_toolkit/referral/analyses/branch_density.py
@@ -18,7 +18,7 @@ def analyze_branch_density(ctx: ReferralContext) -> AnalysisResult:
     m = ctx.referrer_metrics
 
     if df.empty or m.empty:
-        return AnalysisResult(name=name, title=name, df=pd.DataFrame(), sheet_name="R06_Branch")
+        return AnalysisResult.from_df(name, name, pd.DataFrame(), sheet_name="R06_Branch")
 
     # Exclude unknown branches
     df = df[df["Branch Code"] != "UNKNOWN"].copy()
@@ -61,4 +61,4 @@ def analyze_branch_density(ctx: ReferralContext) -> AnalysisResult:
 
     branch = branch.sort_values("Avg Influence Score", ascending=False).reset_index(drop=True)
 
-    return AnalysisResult(name=name, title=name, df=branch, sheet_name="R06_Branch")
+    return AnalysisResult.from_df(name, name, branch, sheet_name="R06_Branch")

--- a/packages/ics_toolkit/src/ics_toolkit/referral/analyses/code_health.py
+++ b/packages/ics_toolkit/src/ics_toolkit/referral/analyses/code_health.py
@@ -15,10 +15,10 @@ def analyze_code_health(ctx: ReferralContext) -> AnalysisResult:
 
     if df.empty:
         empty = pd.DataFrame()
-        return AnalysisResult(
-            name=name,
-            title=name,
-            df=empty,
+        return AnalysisResult.from_df(
+            name,
+            name,
+            empty,
             sheet_name="R07_Code_Health",
         )
 
@@ -49,4 +49,4 @@ def analyze_code_health(ctx: ReferralContext) -> AnalysisResult:
         inplace=True,
     )
 
-    return AnalysisResult(name=name, title=name, df=summary, sheet_name="R07_Code_Health")
+    return AnalysisResult.from_df(name, name, summary, sheet_name="R07_Code_Health")

--- a/packages/ics_toolkit/src/ics_toolkit/referral/analyses/dormant_referrers.py
+++ b/packages/ics_toolkit/src/ics_toolkit/referral/analyses/dormant_referrers.py
@@ -19,11 +19,11 @@ def analyze_dormant_referrers(ctx: ReferralContext) -> AnalysisResult:
     m = ctx.referrer_metrics.copy()
 
     if m.empty:
-        return AnalysisResult(name=name, title=name, df=m, sheet_name="R03_Dormant")
+        return AnalysisResult.from_df(name, name, m, sheet_name="R03_Dormant")
 
     max_date = ctx.df["Issue Date"].max()
     if pd.isna(max_date):
-        return AnalysisResult(name=name, title=name, df=pd.DataFrame(), sheet_name="R03_Dormant")
+        return AnalysisResult.from_df(name, name, pd.DataFrame(), sheet_name="R03_Dormant")
 
     dormancy_cutoff = max_date - pd.Timedelta(days=ctx.settings.dormancy_days)
 
@@ -31,7 +31,7 @@ def analyze_dormant_referrers(ctx: ReferralContext) -> AnalysisResult:
     dormant = m[m["last_referral"] < dormancy_cutoff].copy()
 
     if dormant.empty:
-        return AnalysisResult(name=name, title=name, df=pd.DataFrame(), sheet_name="R03_Dormant")
+        return AnalysisResult.from_df(name, name, pd.DataFrame(), sheet_name="R03_Dormant")
 
     # High-value: meets min referrals OR top quartile influence
     score_q75 = m["Influence Score"].quantile(0.75) if len(m) >= 4 else 0
@@ -54,4 +54,4 @@ def analyze_dormant_referrers(ctx: ReferralContext) -> AnalysisResult:
     out = high_value[list(available.keys())].rename(columns=available)
     out = out.sort_values("Historical Score", ascending=False).reset_index(drop=True)
 
-    return AnalysisResult(name=name, title=name, df=out, sheet_name="R03_Dormant")
+    return AnalysisResult.from_df(name, name, out, sheet_name="R03_Dormant")

--- a/packages/ics_toolkit/src/ics_toolkit/referral/analyses/emerging_referrers.py
+++ b/packages/ics_toolkit/src/ics_toolkit/referral/analyses/emerging_referrers.py
@@ -19,11 +19,11 @@ def analyze_emerging_referrers(ctx: ReferralContext) -> AnalysisResult:
     df = ctx.df
 
     if m.empty:
-        return AnalysisResult(name=name, title=name, df=m, sheet_name="R02_Emerging")
+        return AnalysisResult.from_df(name, name, m, sheet_name="R02_Emerging")
 
     max_date = df["Issue Date"].max()
     if pd.isna(max_date):
-        return AnalysisResult(name=name, title=name, df=pd.DataFrame(), sheet_name="R02_Emerging")
+        return AnalysisResult.from_df(name, name, pd.DataFrame(), sheet_name="R02_Emerging")
 
     lookback_cutoff = max_date - pd.Timedelta(days=ctx.settings.emerging_lookback_days)
 
@@ -46,4 +46,4 @@ def analyze_emerging_referrers(ctx: ReferralContext) -> AnalysisResult:
     out = emerging[list(available.keys())].rename(columns=available)
     out = out.sort_values("Influence Score", ascending=False).reset_index(drop=True)
 
-    return AnalysisResult(name=name, title=name, df=out, sheet_name="R02_Emerging")
+    return AnalysisResult.from_df(name, name, out, sheet_name="R02_Emerging")

--- a/packages/ics_toolkit/src/ics_toolkit/referral/analyses/onetime_vs_repeat.py
+++ b/packages/ics_toolkit/src/ics_toolkit/referral/analyses/onetime_vs_repeat.py
@@ -17,7 +17,7 @@ def analyze_onetime_vs_repeat(ctx: ReferralContext) -> AnalysisResult:
     m = ctx.referrer_metrics.copy()
 
     if m.empty:
-        return AnalysisResult(name=name, title=name, df=pd.DataFrame(), sheet_name="R04_Repeat")
+        return AnalysisResult.from_df(name, name, pd.DataFrame(), sheet_name="R04_Repeat")
 
     m["Category"] = m["total_referrals"].apply(lambda x: "Repeat" if x >= 2 else "One-time")
 
@@ -66,4 +66,4 @@ def analyze_onetime_vs_repeat(ctx: ReferralContext) -> AnalysisResult:
     )
     summary = pd.concat([summary, total_row], ignore_index=True)
 
-    return AnalysisResult(name=name, title=name, df=summary, sheet_name="R04_Repeat")
+    return AnalysisResult.from_df(name, name, summary, sheet_name="R04_Repeat")

--- a/packages/ics_toolkit/src/ics_toolkit/referral/analyses/overview.py
+++ b/packages/ics_toolkit/src/ics_toolkit/referral/analyses/overview.py
@@ -79,4 +79,4 @@ def analyze_overview(
         kpis.append(("Avg Network Size", round(avg_net, 1) if pd.notna(avg_net) else "N/A"))
 
     out = pd.DataFrame(kpis, columns=["Metric", "Value"])
-    return AnalysisResult(name=name, title=name, df=out, sheet_name="R08_Overview")
+    return AnalysisResult.from_df(name, name, out, sheet_name="R08_Overview")

--- a/packages/ics_toolkit/src/ics_toolkit/referral/analyses/staff_multipliers.py
+++ b/packages/ics_toolkit/src/ics_toolkit/referral/analyses/staff_multipliers.py
@@ -12,7 +12,7 @@ def analyze_staff_multipliers(ctx: ReferralContext) -> AnalysisResult:
     s = ctx.staff_metrics.copy()
 
     if s.empty:
-        return AnalysisResult(name=name, title=name, df=s, sheet_name="R05_Staff")
+        return AnalysisResult.from_df(name, name, s, sheet_name="R05_Staff")
 
     cols = {
         "Staff": "Staff",
@@ -27,4 +27,4 @@ def analyze_staff_multipliers(ctx: ReferralContext) -> AnalysisResult:
     out["Avg Referrer Score"] = out["Avg Referrer Score"].round(1)
     out = out.sort_values("Multiplier Score", ascending=False).reset_index(drop=True)
 
-    return AnalysisResult(name=name, title=name, df=out, sheet_name="R05_Staff")
+    return AnalysisResult.from_df(name, name, out, sheet_name="R05_Staff")

--- a/packages/ics_toolkit/src/ics_toolkit/referral/analyses/top_referrers.py
+++ b/packages/ics_toolkit/src/ics_toolkit/referral/analyses/top_referrers.py
@@ -15,7 +15,7 @@ def analyze_top_referrers(ctx: ReferralContext) -> AnalysisResult:
     m = ctx.referrer_metrics.copy()
 
     if m.empty:
-        return AnalysisResult(name=name, title=name, df=m, sheet_name="R01_Top_Referrers")
+        return AnalysisResult.from_df(name, name, m, sheet_name="R01_Top_Referrers")
 
     # Exclude single-referral referrers
     m = m[m["total_referrals"] > 1].copy()
@@ -37,4 +37,4 @@ def analyze_top_referrers(ctx: ReferralContext) -> AnalysisResult:
     out = out.sort_values("Influence Score", ascending=False).head(ctx.settings.top_n_referrers)
     out = out.reset_index(drop=True)
 
-    return AnalysisResult(name=name, title=name, df=out, sheet_name="R01_Top_Referrers")
+    return AnalysisResult.from_df(name, name, out, sheet_name="R01_Top_Referrers")

--- a/packages/shared/src/shared/helpers.py
+++ b/packages/shared/src/shared/helpers.py
@@ -1,0 +1,19 @@
+"""Shared helper functions used across analysis pipelines."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def safe_percentage(numerator: float, denominator: float) -> float:
+    """Compute percentage with zero-division and NaN guard. Returns 0-100."""
+    if denominator == 0 or pd.isna(denominator):
+        return 0.0
+    return round((numerator / denominator) * 100, 2)
+
+
+def safe_ratio(numerator: float, denominator: float, decimals: int = 2) -> float:
+    """Compute ratio with zero-division and NaN guard."""
+    if denominator == 0 or pd.isna(denominator):
+        return 0.0
+    return round(numerator / denominator, decimals)

--- a/packages/shared/src/shared/types.py
+++ b/packages/shared/src/shared/types.py
@@ -11,10 +11,65 @@ import pandas as pd
 
 @dataclass(frozen=True)
 class AnalysisResult:
-    """Immutable container for a single analysis output."""
+    """Immutable container for a single analysis output.
+
+    This is the canonical result type shared across all pipelines (ARS, TXN, ICS).
+    Each pipeline's runner converts internal results to this type at the boundary.
+
+    Fields:
+        name: Unique identifier for the analysis (e.g., "top_merchants_by_spend").
+        title: Human-readable display title (e.g., "Top Merchants by Spend").
+        data: Dict of DataFrames. Use ``{"main": df}`` for single-DataFrame results.
+        charts: List of chart image paths (PNG).
+        error: Error message if the analysis failed; None on success.
+        summary: Brief text summary of findings.
+        metadata: Arbitrary extra data (sheet_name, slide_id, counts, etc.).
+    """
 
     name: str
+    title: str = ""
     data: dict[str, pd.DataFrame] = field(default_factory=dict)
     charts: list[Path] = field(default_factory=list)
+    error: str | None = None
     summary: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def success(self) -> bool:
+        """True if the analysis completed without error."""
+        return self.error is None
+
+    @property
+    def df(self) -> pd.DataFrame:
+        """Convenience: return the 'main' DataFrame, or empty if missing."""
+        return self.data.get("main", pd.DataFrame())
+
+    @property
+    def sheet_name(self) -> str:
+        """Convenience: return sheet_name from metadata, or derive from name."""
+        return self.metadata.get("sheet_name", self.name.replace(" ", "_")[:31])
+
+    @classmethod
+    def from_df(
+        cls,
+        name: str,
+        title: str,
+        df: pd.DataFrame,
+        *,
+        error: str | None = None,
+        sheet_name: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> AnalysisResult:
+        """Create a result from a single DataFrame (convenience for ICS/TXN)."""
+        meta = dict(metadata) if metadata else {}
+        if sheet_name is not None:
+            meta["sheet_name"] = sheet_name
+        elif "sheet_name" not in meta:
+            meta["sheet_name"] = name.replace(" ", "_")[:31]
+        return cls(
+            name=name,
+            title=title,
+            data={"main": df} if df is not None else {},
+            error=error,
+            metadata=meta,
+        )

--- a/packages/txn_analysis/src/txn_analysis/analyses/__init__.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/__init__.py
@@ -154,6 +154,6 @@ def run_all_analyses(
             context["completed_results"][name] = result
         except Exception as e:
             logger.warning("Analysis '%s' failed: %s", name, e)
-            results.append(AnalysisResult(name=name, title=name, df=pd.DataFrame(), error=str(e)))
+            results.append(AnalysisResult.from_df(name, name, pd.DataFrame(), error=str(e)))
 
     return results

--- a/packages/txn_analysis/src/txn_analysis/analyses/base.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/base.py
@@ -1,29 +1,18 @@
-"""Base types and helpers for all analyses."""
+"""Base types and helpers for all analyses.
+
+Canonical types and helpers live in the ``shared`` package.
+Re-exported here so existing TXN code needs zero import changes.
+``add_grand_total`` is TXN-specific and stays here.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import pandas as pd
 
+from shared.helpers import safe_percentage
+from shared.types import AnalysisResult
 
-@dataclass
-class AnalysisResult:
-    """Outcome of a single analysis function."""
-
-    name: str
-    title: str
-    df: pd.DataFrame
-    error: str | None = None
-    sheet_name: str | None = None
-    metadata: dict = field(default_factory=dict)
-
-
-def safe_percentage(part: float, total: float) -> float:
-    """Return part/total * 100 without ZeroDivisionError."""
-    if total == 0:
-        return 0.0
-    return round((part / total) * 100, 2)
+__all__ = ["AnalysisResult", "safe_percentage", "add_grand_total"]
 
 
 def add_grand_total(df: pd.DataFrame, label_col: str) -> pd.DataFrame:

--- a/packages/txn_analysis/src/txn_analysis/analyses/business.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/business.py
@@ -22,10 +22,10 @@ def analyze_business_top_by_spend(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="business_top_by_spend",
-        title="Business - Top Merchants by Spend",
-        df=result,
+    return AnalysisResult.from_df(
+        "business_top_by_spend",
+        "Business - Top Merchants by Spend",
+        result,
         sheet_name="M3 Biz Spend",
     )
 
@@ -43,10 +43,10 @@ def analyze_business_top_by_transactions(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="business_top_by_transactions",
-        title="Business - Top Merchants by Transactions",
-        df=result,
+    return AnalysisResult.from_df(
+        "business_top_by_transactions",
+        "Business - Top Merchants by Transactions",
+        result,
         sheet_name="M3 Biz Transactions",
     )
 
@@ -64,9 +64,9 @@ def analyze_business_top_by_accounts(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="business_top_by_accounts",
-        title="Business - Top Merchants by Accounts",
-        df=result,
+    return AnalysisResult.from_df(
+        "business_top_by_accounts",
+        "Business - Top Merchants by Accounts",
+        result,
         sheet_name="M3 Biz Accounts",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/competitor_detect.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/competitor_detect.py
@@ -53,9 +53,9 @@ def analyze_competitor_detection(
         context["competitor_data"] = all_competitor_data
         context["competitor_summary"] = summary_df
 
-    return AnalysisResult(
-        name="competitor_detection",
-        title="Competitor Detection",
-        df=summary_df,
+    return AnalysisResult.from_df(
+        "competitor_detection",
+        "Competitor Detection",
+        summary_df,
         sheet_name="M6A Detection",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/competitor_metrics.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/competitor_metrics.py
@@ -25,10 +25,10 @@ def analyze_competitor_high_level(
     """M6B-1: High-level competitor metrics summary."""
     _, summary = _get_context_data(context)
     if summary.empty:
-        return AnalysisResult(
-            name="competitor_high_level",
-            title="Competitor High Level Metrics",
-            df=pd.DataFrame(),
+        return AnalysisResult.from_df(
+            "competitor_high_level",
+            "Competitor High Level Metrics",
+            pd.DataFrame(),
             sheet_name="M6B-1 Metrics",
         )
 
@@ -52,10 +52,10 @@ def analyze_competitor_high_level(
         ]
     )
 
-    return AnalysisResult(
-        name="competitor_high_level",
-        title="Competitor High Level Metrics",
-        df=metrics,
+    return AnalysisResult.from_df(
+        "competitor_high_level",
+        "Competitor High Level Metrics",
+        metrics,
         sheet_name="M6B-1 Metrics",
     )
 
@@ -70,10 +70,10 @@ def analyze_top_20_competitors(
     """M6B-2: Top 20 competitors by spend."""
     _, summary = _get_context_data(context)
     result = summary.head(20).copy() if not summary.empty else pd.DataFrame()
-    return AnalysisResult(
-        name="top_20_competitors",
-        title="Top 20 Competitors by Spend",
-        df=result,
+    return AnalysisResult.from_df(
+        "top_20_competitors",
+        "Top 20 Competitors by Spend",
+        result,
         sheet_name="M6B-2 Top 20",
     )
 
@@ -88,10 +88,10 @@ def analyze_competitor_categories(
     """M6B-3: Competitor category breakdown."""
     _, summary = _get_context_data(context)
     if summary.empty:
-        return AnalysisResult(
-            name="competitor_categories",
-            title="Competitor Category Breakdown",
-            df=pd.DataFrame(),
+        return AnalysisResult.from_df(
+            "competitor_categories",
+            "Competitor Category Breakdown",
+            pd.DataFrame(),
             sheet_name="M6B-3 Categories",
         )
 
@@ -112,10 +112,10 @@ def analyze_competitor_categories(
     )
     cat = cat.sort_values("total_amount", ascending=False).reset_index(drop=True)
 
-    return AnalysisResult(
-        name="competitor_categories",
-        title="Competitor Category Breakdown",
-        df=cat,
+    return AnalysisResult.from_df(
+        "competitor_categories",
+        "Competitor Category Breakdown",
+        cat,
         sheet_name="M6B-3 Categories",
     )
 
@@ -130,19 +130,19 @@ def analyze_competitor_biz_personal(
     """M6B-4: Business vs personal split for competitor transactions."""
     comp_data, _ = _get_context_data(context)
     if not comp_data:
-        return AnalysisResult(
-            name="competitor_biz_personal",
-            title="Competitor Biz/Personal Split",
-            df=pd.DataFrame(),
+        return AnalysisResult.from_df(
+            "competitor_biz_personal",
+            "Competitor Biz/Personal Split",
+            pd.DataFrame(),
             sheet_name="M6B-4 Biz Personal",
         )
 
     all_comp = pd.concat(comp_data.values(), ignore_index=True)
     if "business_flag" not in all_comp.columns:
-        return AnalysisResult(
-            name="competitor_biz_personal",
-            title="Competitor Biz/Personal Split",
-            df=pd.DataFrame(),
+        return AnalysisResult.from_df(
+            "competitor_biz_personal",
+            "Competitor Biz/Personal Split",
+            pd.DataFrame(),
             sheet_name="M6B-4 Biz Personal",
         )
 
@@ -158,10 +158,10 @@ def analyze_competitor_biz_personal(
         .reset_index()
     )
 
-    return AnalysisResult(
-        name="competitor_biz_personal",
-        title="Competitor Biz/Personal Split",
-        df=split,
+    return AnalysisResult.from_df(
+        "competitor_biz_personal",
+        "Competitor Biz/Personal Split",
+        split,
         sheet_name="M6B-4 Biz Personal",
     )
 
@@ -176,19 +176,19 @@ def analyze_competitor_monthly_trends(
     """M6B-5: Monthly competitor spend/transaction trends."""
     comp_data, _ = _get_context_data(context)
     if not comp_data:
-        return AnalysisResult(
-            name="competitor_monthly_trends",
-            title="Competitor Monthly Trends",
-            df=pd.DataFrame(),
+        return AnalysisResult.from_df(
+            "competitor_monthly_trends",
+            "Competitor Monthly Trends",
+            pd.DataFrame(),
             sheet_name="M6B-5 Monthly",
         )
 
     all_comp = pd.concat(comp_data.values(), ignore_index=True)
     if "year_month" not in all_comp.columns:
-        return AnalysisResult(
-            name="competitor_monthly_trends",
-            title="Competitor Monthly Trends",
-            df=pd.DataFrame(),
+        return AnalysisResult.from_df(
+            "competitor_monthly_trends",
+            "Competitor Monthly Trends",
+            pd.DataFrame(),
             sheet_name="M6B-5 Monthly",
         )
 
@@ -207,9 +207,9 @@ def analyze_competitor_monthly_trends(
     monthly["spend_growth_pct"] = monthly["total_spend"].pct_change() * 100
     monthly["spend_growth_pct"] = monthly["spend_growth_pct"].round(2)
 
-    return AnalysisResult(
-        name="competitor_monthly_trends",
-        title="Competitor Monthly Trends",
-        df=monthly,
+    return AnalysisResult.from_df(
+        "competitor_monthly_trends",
+        "Competitor Monthly Trends",
+        monthly,
         sheet_name="M6B-5 Monthly",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/competitor_segment.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/competitor_segment.py
@@ -65,18 +65,18 @@ def analyze_competitor_segmentation(
         lambda r: safe_percentage(r["competitor_spend"], r["total_spend"]), axis=1
     )
 
-    return AnalysisResult(
-        name="competitor_segmentation",
-        title="Competitor Account Segmentation",
-        df=segment_summary,
+    return AnalysisResult.from_df(
+        "competitor_segmentation",
+        "Competitor Account Segmentation",
+        segment_summary,
         sheet_name="M6 Segmentation",
     )
 
 
 def _empty_result() -> AnalysisResult:
-    return AnalysisResult(
-        name="competitor_segmentation",
-        title="Competitor Account Segmentation",
-        df=pd.DataFrame(),
+    return AnalysisResult.from_df(
+        "competitor_segmentation",
+        "Competitor Account Segmentation",
+        pd.DataFrame(),
         sheet_name="M6 Segmentation",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/competitor_threat.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/competitor_threat.py
@@ -62,10 +62,10 @@ def analyze_threat_assessment(
     result = result.drop(columns=["_pen_rank", "_spend_rank", "_growth_rank"])
     result = result.sort_values("threat_score", ascending=False).head(10).reset_index(drop=True)
 
-    return AnalysisResult(
-        name="competitor_threat_assessment",
-        title="Competitor Threat Assessment",
-        df=result,
+    return AnalysisResult.from_df(
+        "competitor_threat_assessment",
+        "Competitor Threat Assessment",
+        result,
         sheet_name="M6B-6 Threat",
     )
 
@@ -89,9 +89,9 @@ def _calc_growth_rate(comp_df: pd.DataFrame, months: list[str]) -> float:
 
 
 def _empty_result() -> AnalysisResult:
-    return AnalysisResult(
-        name="competitor_threat_assessment",
-        title="Competitor Threat Assessment",
-        df=pd.DataFrame(),
+    return AnalysisResult.from_df(
+        "competitor_threat_assessment",
+        "Competitor Threat Assessment",
+        pd.DataFrame(),
         sheet_name="M6B-6 Threat",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/financial_services.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/financial_services.py
@@ -69,10 +69,10 @@ def analyze_financial_services_detection(
     if not result.empty:
         result = result.sort_values("total_spend", ascending=False).reset_index(drop=True)
 
-    return AnalysisResult(
-        name="financial_services_detection",
-        title="Financial Services Detection",
-        df=result,
+    return AnalysisResult.from_df(
+        "financial_services_detection",
+        "Financial Services Detection",
+        result,
         sheet_name="M7 Detection",
     )
 
@@ -103,10 +103,10 @@ def analyze_financial_services_summary(
         det_df = detection.df
 
     if det_df.empty:
-        return AnalysisResult(
-            name="financial_services_summary",
-            title="Financial Services Summary",
-            df=pd.DataFrame(),
+        return AnalysisResult.from_df(
+            "financial_services_summary",
+            "Financial Services Summary",
+            pd.DataFrame(),
             sheet_name="M7 Summary",
         )
 
@@ -134,9 +134,9 @@ def analyze_financial_services_summary(
         ]
     )
 
-    return AnalysisResult(
-        name="financial_services_summary",
-        title="Financial Services Summary",
-        df=summary,
+    return AnalysisResult.from_df(
+        "financial_services_summary",
+        "Financial Services Summary",
+        summary,
         sheet_name="M7 Summary",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/interchange.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/interchange.py
@@ -33,10 +33,10 @@ def analyze_interchange_summary(
                 "total_ic_revenue": 0.0,
                 "ic_rate": ic_rate,
             }
-        return AnalysisResult(
-            name="interchange_summary",
-            title="Interchange Revenue Summary",
-            df=pd.DataFrame(),
+        return AnalysisResult.from_df(
+            "interchange_summary",
+            "Interchange Revenue Summary",
+            pd.DataFrame(),
             sheet_name="M8 IC Summary",
             metadata={"ic_rate": ic_rate, "note": "IC rate not configured"},
         )
@@ -154,10 +154,10 @@ def analyze_interchange_summary(
             "personal_spend": round(personal_df["amount"].sum(), 2),
         }
 
-    return AnalysisResult(
-        name="interchange_summary",
-        title="Interchange Revenue Summary (Estimated)",
-        df=result,
+    return AnalysisResult.from_df(
+        "interchange_summary",
+        "Interchange Revenue Summary (Estimated)",
+        result,
         sheet_name="M8 IC Summary",
         metadata={
             "ic_rate": ic_rate,

--- a/packages/txn_analysis/src/txn_analysis/analyses/mcc.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/mcc.py
@@ -22,10 +22,10 @@ def analyze_mcc_by_accounts(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="mcc_by_accounts",
-        title="Top MCC Codes by Unique Accounts",
-        df=result,
+    return AnalysisResult.from_df(
+        "mcc_by_accounts",
+        "Top MCC Codes by Unique Accounts",
+        result,
         sheet_name="M2 MCC Accounts",
     )
 
@@ -43,10 +43,10 @@ def analyze_mcc_by_transactions(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="mcc_by_transactions",
-        title="Top MCC Codes by Transaction Count",
-        df=result,
+    return AnalysisResult.from_df(
+        "mcc_by_transactions",
+        "Top MCC Codes by Transaction Count",
+        result,
         sheet_name="M2 MCC Transactions",
     )
 
@@ -64,9 +64,9 @@ def analyze_mcc_by_spend(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="mcc_by_spend",
-        title="Top MCC Codes by Total Spend",
-        df=result,
+    return AnalysisResult.from_df(
+        "mcc_by_spend",
+        "Top MCC Codes by Total Spend",
+        result,
         sheet_name="M2 MCC Spend",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/member_segments.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/member_segments.py
@@ -94,10 +94,10 @@ def analyze_member_segments(
             ),
         }
 
-    return AnalysisResult(
-        name="member_segments",
-        title="Account Segmentation by Spend Tier",
-        df=seg_summary,
+    return AnalysisResult.from_df(
+        "member_segments",
+        "Account Segmentation by Spend Tier",
+        seg_summary,
         sheet_name="M10 Segments",
         metadata={"dormant_threshold_days": dormant_threshold},
     )
@@ -127,9 +127,9 @@ def _classify_accounts(acct: pd.DataFrame, dormant_days: int) -> pd.Series:
 
 
 def _empty_result() -> AnalysisResult:
-    return AnalysisResult(
-        name="member_segments",
-        title="Account Segmentation by Spend Tier",
-        df=pd.DataFrame(),
+    return AnalysisResult.from_df(
+        "member_segments",
+        "Account Segmentation by Spend Tier",
+        pd.DataFrame(),
         sheet_name="M10 Segments",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/overall.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/overall.py
@@ -22,10 +22,10 @@ def analyze_top_by_spend(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="top_merchants_by_spend",
-        title="Top Merchants by Total Spend",
-        df=result,
+    return AnalysisResult.from_df(
+        "top_merchants_by_spend",
+        "Top Merchants by Total Spend",
+        result,
         sheet_name="M1 Top Spend",
     )
 
@@ -43,10 +43,10 @@ def analyze_top_by_transactions(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="top_merchants_by_transactions",
-        title="Top Merchants by Transaction Count",
-        df=result,
+    return AnalysisResult.from_df(
+        "top_merchants_by_transactions",
+        "Top Merchants by Transaction Count",
+        result,
         sheet_name="M1 Top Transactions",
     )
 
@@ -64,9 +64,9 @@ def analyze_top_by_accounts(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="top_merchants_by_accounts",
-        title="Top Merchants by Unique Accounts",
-        df=result,
+    return AnalysisResult.from_df(
+        "top_merchants_by_accounts",
+        "Top Merchants by Unique Accounts",
+        result,
         sheet_name="M1 Top Accounts",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/personal.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/personal.py
@@ -22,10 +22,10 @@ def analyze_personal_top_by_spend(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="personal_top_by_spend",
-        title="Personal - Top Merchants by Spend",
-        df=result,
+    return AnalysisResult.from_df(
+        "personal_top_by_spend",
+        "Personal - Top Merchants by Spend",
+        result,
         sheet_name="M4 Personal Spend",
     )
 
@@ -43,10 +43,10 @@ def analyze_personal_top_by_transactions(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="personal_top_by_transactions",
-        title="Personal - Top Merchants by Transactions",
-        df=result,
+    return AnalysisResult.from_df(
+        "personal_top_by_transactions",
+        "Personal - Top Merchants by Transactions",
+        result,
         sheet_name="M4 Personal Transactions",
     )
 
@@ -64,9 +64,9 @@ def analyze_personal_top_by_accounts(
         top_n=settings.top_n,
         ic_rate=settings.ic_rate,
     )
-    return AnalysisResult(
-        name="personal_top_by_accounts",
-        title="Personal - Top Merchants by Accounts",
-        df=result,
+    return AnalysisResult.from_df(
+        "personal_top_by_accounts",
+        "Personal - Top Merchants by Accounts",
+        result,
         sheet_name="M4 Personal Accounts",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/scorecard.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/scorecard.py
@@ -146,10 +146,10 @@ def analyze_portfolio_scorecard(
 
     result = pd.DataFrame(rows)
 
-    return AnalysisResult(
-        name="portfolio_scorecard",
-        title="Portfolio Health Scorecard",
-        df=result,
+    return AnalysisResult.from_df(
+        "portfolio_scorecard",
+        "Portfolio Health Scorecard",
+        result,
         sheet_name="M9 Scorecard",
         metadata={
             "months_in_data": months_in_data,
@@ -186,9 +186,9 @@ def _kpi(
 
 
 def _empty_result() -> AnalysisResult:
-    return AnalysisResult(
-        name="portfolio_scorecard",
-        title="Portfolio Health Scorecard",
-        df=pd.DataFrame(),
+    return AnalysisResult.from_df(
+        "portfolio_scorecard",
+        "Portfolio Health Scorecard",
+        pd.DataFrame(),
         sheet_name="M9 Scorecard",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/storyline_adapters.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/storyline_adapters.py
@@ -42,10 +42,10 @@ def _wrap_storyline_result(
     """Convert a V4 storyline result dict into an AnalysisResult."""
     sheets = result.get("sheets", [])
     primary_df = sheets[0]["df"] if sheets else pd.DataFrame()
-    return AnalysisResult(
-        name=name,
-        title=result.get("title", name),
-        df=primary_df,
+    return AnalysisResult.from_df(
+        name,
+        result.get("title", name),
+        primary_df,
         metadata={
             "storyline": result,
             "section_count": len(result.get("sections", [])),

--- a/packages/txn_analysis/src/txn_analysis/analyses/trends_cohort.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/trends_cohort.py
@@ -56,9 +56,9 @@ def analyze_new_vs_declining(
         prev_merchants = current_merchants
 
     result = pd.DataFrame(rows)
-    return AnalysisResult(
-        name="new_vs_declining_merchants",
-        title="New vs Declining Merchants",
-        df=result,
+    return AnalysisResult.from_df(
+        "new_vs_declining_merchants",
+        "New vs Declining Merchants",
+        result,
         sheet_name="M5D Cohorts",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/trends_consistency.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/trends_consistency.py
@@ -57,18 +57,18 @@ def analyze_spending_consistency(
 
     result = pd.DataFrame(rows)
     if result.empty:
-        return AnalysisResult(
-            name="spending_consistency",
-            title="Spending Consistency Analysis",
-            df=result,
+        return AnalysisResult.from_df(
+            "spending_consistency",
+            "Spending Consistency Analysis",
+            result,
             sheet_name="M5C Consistency",
         )
 
     result = result.sort_values("consistency_score", ascending=False).reset_index(drop=True)
 
-    return AnalysisResult(
-        name="spending_consistency",
-        title="Spending Consistency Analysis",
-        df=result,
+    return AnalysisResult.from_df(
+        "spending_consistency",
+        "Spending Consistency Analysis",
+        result,
         sheet_name="M5C Consistency",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/trends_growth.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/trends_growth.py
@@ -55,10 +55,10 @@ def analyze_growth_leaders_decliners(
 
     result = pd.DataFrame(rows)
     if result.empty:
-        return AnalysisResult(
-            name="growth_leaders_decliners",
-            title="Growth Leaders and Decliners",
-            df=result,
+        return AnalysisResult.from_df(
+            "growth_leaders_decliners",
+            "Growth Leaders and Decliners",
+            result,
             sheet_name="M5B Growth",
         )
 
@@ -66,9 +66,9 @@ def analyze_growth_leaders_decliners(
     decliners = result.nsmallest(settings.top_n, "change_amount")
     combined = pd.concat([leaders, decliners], ignore_index=True).drop_duplicates()
 
-    return AnalysisResult(
-        name="growth_leaders_decliners",
-        title="Growth Leaders and Decliners",
-        df=combined,
+    return AnalysisResult.from_df(
+        "growth_leaders_decliners",
+        "Growth Leaders and Decliners",
+        combined,
         sheet_name="M5B Growth",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/trends_movers.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/trends_movers.py
@@ -66,10 +66,10 @@ def analyze_business_movers(
     context: dict | None = None,
 ) -> AnalysisResult:
     result = _compute_movers(business_df, top_n=settings.top_n)
-    return AnalysisResult(
-        name="business_monthly_movers",
-        title="Business Monthly Movers",
-        df=result,
+    return AnalysisResult.from_df(
+        "business_monthly_movers",
+        "Business Monthly Movers",
+        result,
         sheet_name="M5E Biz Movers",
     )
 
@@ -82,9 +82,9 @@ def analyze_personal_movers(
     context: dict | None = None,
 ) -> AnalysisResult:
     result = _compute_movers(personal_df, top_n=settings.top_n)
-    return AnalysisResult(
-        name="personal_monthly_movers",
-        title="Personal Monthly Movers",
-        df=result,
+    return AnalysisResult.from_df(
+        "personal_monthly_movers",
+        "Personal Monthly Movers",
+        result,
         sheet_name="M5F Personal Movers",
     )

--- a/packages/txn_analysis/src/txn_analysis/analyses/trends_rank.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/trends_rank.py
@@ -38,9 +38,9 @@ def analyze_monthly_rank_tracking(
 
     result = result.sort_values("avg_rank").head(settings.top_n).reset_index(drop=True)
 
-    return AnalysisResult(
-        name="monthly_rank_tracking",
-        title="Monthly Merchant Rank Tracking",
-        df=result,
+    return AnalysisResult.from_df(
+        "monthly_rank_tracking",
+        "Monthly Merchant Rank Tracking",
+        result,
         sheet_name="M5A Rank Tracking",
     )

--- a/plans/chore-consolidate-moving-parts.md
+++ b/plans/chore-consolidate-moving-parts.md
@@ -1,3 +1,5 @@
+> **SUPERSEDED** by `chore-unified-consolidation.md` (2026-02-13). Phase 1 of this plan was completed; remaining phases merged into the unified plan.
+
 # Consolidate Moving Parts -- Platform Stabilization Roadmap
 
 **Type:** chore/stabilization

--- a/plans/chore-unified-consolidation.md
+++ b/plans/chore-unified-consolidation.md
@@ -1,0 +1,307 @@
+# Unified Consolidation Plan
+
+**Type:** chore/architecture
+**Created:** 2026-02-13
+**Context:** Merging 3 overlapping plans into one actionable path. Previous session shipped V4 consolidation (PR #17), ARS CLI fix (PR #18), stale branch cleanup, and issue triage. This plan picks up the critical path.
+
+---
+
+## Situation Assessment
+
+### What's Real (verified 2026-02-13)
+
+| Metric | Value |
+|--------|-------|
+| Branch | `main` (clean, up to date with `6a77e89`) |
+| Tests | **2,318 passing** (13 ARS collection failures from HANDOFF are RESOLVED) |
+| Coverage | 89% (CI floor 80%) |
+| Lint | Clean |
+| Open PRs | 0 |
+| Open Issues | 1 (#14 -- but see below) |
+
+### What's Stale
+
+1. **Issue #14 ("Wire Pipeline Execution") is DONE** -- `run_analysis.py` already calls `run_pipeline()` via orchestrator with progress tracking, error handling, and results display. The issue should be closed.
+
+2. **HANDOFF.md says "13 ARS collection failures"** -- these are resolved. All 545 ARS tests collect and pass.
+
+3. **3 overlapping plans** exist:
+   - `chore-consolidate-moving-parts.md` -- Phase 1 done, Phases 2-5 are environment-dependent (Windows/real data)
+   - `feat-platform-enhancement-roadmap.md` -- Tier 1 done, Tier 2 partially done, Tiers 3-5 open
+   - `feat-streamlit-platform-ui.md` -- UI is built; execution is wired; largely complete
+
+4. **CLAUDE.md** references "Session Pickup: 2026-02-07" and stale PR state
+
+### What Actually Needs Doing (in order)
+
+```
+Phase 1: Housekeeping (30 min)                    <-- unblock everything
+    Close #14, update docs, deprecate stale plans
+         |
+Phase 2: Unify AnalysisResult (2-4 hours)         <-- CRITICAL PATH
+    4 definitions -> 1 in shared.types
+         |
+Phase 3: Deduplicate helpers (1 hour)             <-- quick win after Phase 2
+    safe_percentage, safe_ratio -> shared
+         |
+Phase 4: End-to-end validation (1-2 hours)        <-- FIRST REAL TEST
+    Run each pipeline with actual data
+         |
+Phase 5: Decompose storyline monoliths (2 hours)  <-- nice to have
+    S5/S7/S8/S9 -> small focused modules
+         |
+Phase 6: Future features (deferred)
+    Reg E enhancement, chart formatting, cross-pipeline dashboard
+```
+
+---
+
+## Phase 1: Housekeeping (30 min)
+
+Quick cleanup to reflect reality.
+
+### 1.1 Close Issue #14
+
+`run_analysis.py` lines 174-188 already call `run_pipeline()` with:
+- Product detection from selected modules
+- Input file resolution per pipeline
+- Progress bar with status updates
+- Per-pipeline error capture and display
+- Results logging via `RunRecord`
+
+**Action:** Close #14 with comment explaining it was implemented during V4 consolidation.
+
+- [x] `gh issue close 14 --comment "..."`
+
+### 1.2 Update CLAUDE.md
+
+Current CLAUDE.md references "Session Pickup: 2026-02-07" and stale PR state.
+
+- [x] Update to current state: 2,318 tests, 89% coverage, 0 open PRs, 0 open issues
+- [x] Point to this plan as the active roadmap
+- [x] Remove references to stale plans
+
+### 1.3 Update HANDOFF.md
+
+- [x] Fix "13 ARS pre-existing collection failures" -> "all resolved"
+- [x] Update test count: 2,318 (was 2,305)
+- [x] Mark Issue #14 as closed in the issues table
+
+### 1.4 Deprecate overlapping plans
+
+- [x] Add "SUPERSEDED by chore-unified-consolidation.md" banner to:
+  - `chore-consolidate-moving-parts.md` (Phase 1 done; rest is environment-dependent)
+  - `feat-platform-enhancement-roadmap.md` (merged into this plan)
+  - `feat-streamlit-platform-ui.md` (UI is built and wired)
+
+---
+
+## Phase 2: Unify AnalysisResult (2-4 hours)
+
+**This is the single most impactful architectural change.** 4 competing definitions create confusion and block true cross-pipeline interop.
+
+### Current State (4 definitions)
+
+| Package | Location | Key Fields |
+|---------|----------|------------|
+| `shared` | `shared/types.py:13` | `name`, `data: dict[str, DataFrame]`, `charts: list[Path]`, `summary`, `metadata` (frozen) |
+| `ars_analysis` | `analytics/base.py:26` | `slide_id`, `title`, `chart_path: Path|None`, `excel_data: dict[str, DataFrame]|None`, `notes`, `success: bool`, `error` (mutable) |
+| `ics_toolkit` | `analysis/analyses/base.py:10` | `name`, `title`, `df: DataFrame`, `error: str|None`, `sheet_name`, `metadata` (mutable) |
+| `txn_analysis` | `analyses/base.py:11` | `name`, `title`, `df: DataFrame`, `error: str|None`, `sheet_name: str|None`, `metadata` (mutable) |
+
+### Target: Unified `shared.types.AnalysisResult`
+
+Design a superset that covers all use cases:
+
+```python
+# packages/shared/src/shared/types.py
+@dataclass
+class AnalysisResult:
+    """Standard output container for a single analysis."""
+    name: str
+    title: str = ""
+    data: dict[str, pd.DataFrame] = field(default_factory=dict)
+    charts: list[Path] = field(default_factory=list)
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+```
+
+Field mapping:
+
+| Old Field | Package | Maps To |
+|-----------|---------|---------|
+| `slide_id` | ARS | `name` |
+| `df` | ICS, TXN | `data["main"]` (single-DF convenience) |
+| `chart_path` | ARS | `charts[0]` (single-chart convenience) |
+| `excel_data` | ARS | `data` (already a dict) |
+| `sheet_name` | ICS, TXN | `metadata["sheet_name"]` |
+| `notes` | ARS | `metadata["notes"]` |
+| `success` | ARS | `error is None` (derived) |
+| `summary` | shared (old) | `metadata["summary"]` |
+
+### Migration Steps
+
+#### 2.1 Extend shared.types.AnalysisResult
+
+- [x] Add `title: str = ""` field
+- [x] Add `error: str | None = None` field
+- [x] Keep `frozen=True` (runners create SharedResult at boundary; ARS keeps its own mutable type internally)
+- [x] Keep `summary: str = ""` for backwards compat
+- [x] Add convenience properties: `@property def df`, `@property def sheet_name`, `@property def success`
+- [x] Add `from_df()` classmethod for ICS/TXN convenience
+- [x] Update shared tests (18 tests, all passing)
+
+#### 2.2 Migrate TXN to shared.types.AnalysisResult
+
+TXN is closest to shared -- lowest risk first.
+
+- [x] Update `txn_analysis/analyses/base.py`: re-export `AnalysisResult` from `shared.types`
+- [x] Update all 46 TXN constructor calls to use `AnalysisResult.from_df()` (19 source files, 3 test files)
+- [x] 597 TXN tests passing + 6 integration tests passing
+
+#### 2.3 Migrate ICS to shared.types.AnalysisResult
+
+ICS is nearly identical to TXN.
+
+- [x] Update `ics_toolkit/analysis/analyses/base.py`: re-export `AnalysisResult` from `shared.types`
+- [x] Update all 186 ICS constructor calls to use `AnalysisResult.from_df()` (23 source files, 7 test files)
+- [x] sheet_name auto-population handled by `from_df()` classmethod
+- [x] 1049 ICS tests passing + 3 integration tests passing
+
+#### 2.4 Migrate ARS to shared.types.AnalysisResult
+
+ARS has the most divergence. Use adapter pattern.
+
+- [x] **Decision: Keep ARS internal type as-is.** ARS has a completely different field structure (slide_id, chart_path, excel_data, success, error vs name, data dict, charts list). The runner.py bridge already converts at the boundary cleanly. Forcing migration would touch 23 source files + 10 test files with zero functional benefit.
+- [x] Result: **1 canonical shared type** (TXN, ICS, platform, orchestrator) + **1 ARS-internal type** (scoped to ars_analysis.analytics.base). Clean boundary via runner.py.
+
+#### 2.5 Update orchestrator
+
+- [x] Verified `orchestrator.py` imports from `shared.types`
+- [x] Verified all pipeline runners return `dict[str, shared.types.AnalysisResult]`
+- [x] All 545 ARS + 597 TXN + 1049 ICS + integration tests passing
+
+---
+
+## Phase 3: Deduplicate Helpers (1 hour)
+
+Quick win after Phase 2 since we're already editing base.py files.
+
+### 3.1 Move safe_percentage to shared
+
+Two implementations exist:
+- **ICS** (`analysis/analyses/base.py:25`): Checks `pd.isna(denominator)` -- more robust
+- **TXN** (`analyses/base.py:22`): No NaN check
+
+- [x] Created `packages/shared/src/shared/helpers.py` with `safe_percentage` + `safe_ratio`
+- [x] Added 13 tests in `tests/shared/test_helpers.py`
+- [x] Updated ICS base.py: re-exports from `shared.helpers` (zero import changes needed downstream)
+- [x] Updated TXN base.py: re-exports from `shared.helpers` (zero import changes needed downstream)
+- [x] Removed local definitions from ICS and TXN base.py
+- [x] All 597 TXN + 1049 ICS tests passing
+
+### 3.2 Leave ConfigError as-is
+
+Each package has its own exception hierarchy (`ICSToolkitError`, `TxnError`, `ARSError`). This is correct design -- package-specific exceptions allow proper error isolation.
+
+**No action needed.**
+
+---
+
+## Phase 4: End-to-End Validation (1-2 hours)
+
+First real-data test of each pipeline. This can run on macOS if you have sample data files, or defer to Windows M: drive.
+
+### 4.1 Test TXN pipeline
+
+- [ ] Find or create a sample transaction CSV (needs: `merchant_name`, `amount`, `primary_account_num`, `transaction_date`, `mcc_code`)
+- [ ] Run: `uv run python -m txn_analysis /path/to/sample.csv`
+- [ ] Verify: Excel output + chart PNGs
+
+### 4.2 Test ICS pipeline
+
+- [ ] Find or create a sample ICS Excel
+- [ ] Run: `uv run python -m ics_toolkit analyze /path/to/sample.xlsx`
+- [ ] Verify: 37 analyses + PPTX
+
+### 4.3 Test ARS pipeline
+
+- [ ] Find a real ODD file (or synthetic with realistic column names and data volume)
+- [ ] Run: `uv run python -m ars_analysis run /path/to/ODD.xlsx`
+- [ ] Verify: Excel + charts + PPTX deck
+
+### 4.4 Test Streamlit UI
+
+- [ ] `uv run streamlit run packages/platform_app/src/platform_app/app.py`
+- [ ] Upload a file, select modules, click Run
+- [ ] Verify progress bar, results display, output files
+
+---
+
+## Phase 5: Decompose Storyline Monoliths (2 hours, optional)
+
+S5/S7/S8/S9 are 267-463 LOC each. They work via thin adapters in `storyline_adapters.py` but are still monolithic.
+
+- [ ] Break each into smaller focused modules
+- [ ] Delete `storylines/` directory once all code is in `analyses/`
+- [ ] Update adapter imports
+- [ ] Ensure M11-M14 registry entries still work
+
+**Priority:** Low. The adapters work. Only do this if time permits.
+
+---
+
+## Phase 6: Deferred Features
+
+These are documented in existing plans but are NOT on the critical path:
+
+| Feature | Plan File | Priority |
+|---------|-----------|----------|
+| Reg E Enhancement (5 sprints) | `feat-reg-e-enhancement.md` | Medium -- product feature |
+| Chart Formatting Fixes | `fix-chart-formatting-spines-positioning.md` | Low -- cosmetic |
+| Cross-Pipeline Dashboard | `feat-platform-enhancement-roadmap.md` T4.2 | Low -- UI polish |
+| PPTX Template System | T4.5 | Low |
+| Windows Deployment | `chore-consolidate-moving-parts.md` Phase 4 | High when deploying |
+| Standalone Repo Archival | `chore-consolidate-moving-parts.md` Phase 3 | Medium -- housekeeping |
+| CI Caching + DevEx | T5 | Low |
+
+---
+
+## Files That Will Change
+
+### Phase 1 (docs only)
+- `CLAUDE.md` -- update current state
+- `HANDOFF.md` -- fix stale test counts
+- `plans/chore-consolidate-moving-parts.md` -- add superseded banner
+- `plans/feat-platform-enhancement-roadmap.md` -- add superseded banner
+- `plans/feat-streamlit-platform-ui.md` -- add superseded banner
+
+### Phase 2 (AnalysisResult unification)
+- `packages/shared/src/shared/types.py` -- extend AnalysisResult
+- `tests/shared/test_types.py` -- new/updated tests
+- `packages/txn_analysis/src/txn_analysis/analyses/base.py` -- remove local definition
+- `packages/txn_analysis/src/txn_analysis/analyses/*.py` -- update constructors (~15 files)
+- `packages/ics_toolkit/src/ics_toolkit/analysis/analyses/base.py` -- remove local definition
+- `packages/ics_toolkit/src/ics_toolkit/analysis/analyses/*.py` -- update constructors (~18 files)
+- `packages/ars_analysis/src/ars_analysis/analytics/base.py` -- remove local definition
+- `packages/ars_analysis/src/ars_analysis/analytics/**/*.py` -- update constructors (~20 files)
+- `packages/platform_app/src/platform_app/orchestrator.py` -- verify imports
+
+### Phase 3 (helper dedup)
+- `packages/shared/src/shared/helpers.py` -- new file
+- `tests/shared/test_helpers.py` -- new tests
+- `packages/ics_toolkit/src/ics_toolkit/analysis/analyses/base.py` -- remove safe_percentage/safe_ratio
+- `packages/txn_analysis/src/txn_analysis/analyses/base.py` -- remove safe_percentage
+- ~23 files updating imports
+
+---
+
+## Success Criteria
+
+- [ ] 0 open issues on analysis-platform
+- [ ] Single `AnalysisResult` definition in `shared.types`, used by all 3 pipelines
+- [ ] No duplicated helper functions across packages
+- [ ] All tests pass (2,318+)
+- [ ] Coverage stays >= 89%
+- [ ] CLAUDE.md and HANDOFF.md reflect reality
+- [ ] At least one pipeline tested with real (non-synthetic) data

--- a/plans/feat-platform-enhancement-roadmap.md
+++ b/plans/feat-platform-enhancement-roadmap.md
@@ -1,3 +1,5 @@
+> **SUPERSEDED** by `chore-unified-consolidation.md` (2026-02-13). Tiers 1-2 done; remaining tiers merged into the unified plan.
+
 # Platform Enhancement Roadmap
 
 **Type:** enhancement

--- a/plans/feat-streamlit-platform-ui.md
+++ b/plans/feat-streamlit-platform-ui.md
@@ -1,3 +1,5 @@
+> **SUPERSEDED** by `chore-unified-consolidation.md` (2026-02-13). UI is built and wired; remaining work is real-data validation.
+
 # Streamlit Analysis Platform -- Integration Plan
 
 **Repo:** `/Users/jgmbp/Desktop/analysis_platform/` (JG-CSI-Velocity/analysis-platform)

--- a/tests/ics/analysis/analyses/test_executive_summary.py
+++ b/tests/ics/analysis/analyses/test_executive_summary.py
@@ -74,10 +74,10 @@ class TestAnalyzeExecutiveSummary:
                 ("Total Spend", 150000.00),
             ]
         )
-        mock_activity = AnalysisResult(
-            name="Activity Summary",
-            title="test",
-            df=activity_kpis,
+        mock_activity = AnalysisResult.from_df(
+            "Activity Summary",
+            "test",
+            activity_kpis,
         )
 
         persona_df = pd.DataFrame(
@@ -94,10 +94,10 @@ class TestAnalyzeExecutiveSummary:
                 "% of Total": [40.0, 20.0, 15.0, 25.0],
             }
         )
-        mock_personas = AnalysisResult(
-            name="Activation Personas",
-            title="test",
-            df=persona_df,
+        mock_personas = AnalysisResult.from_df(
+            "Activation Personas",
+            "test",
+            persona_df,
         )
 
         result = analyze_executive_summary(
@@ -190,7 +190,7 @@ class TestAnalyzeExecutiveSummary:
         self, sample_df, ics_all, ics_stat_o, ics_stat_o_debit, sample_settings
     ):
         activity_kpis = kpi_summary([("% Active", 62.5), ("Total Swipes", 5000)])
-        mock_activity = AnalysisResult(name="Activity Summary", title="test", df=activity_kpis)
+        mock_activity = AnalysisResult.from_df("Activity Summary", "test", activity_kpis)
 
         revenue_kpis = kpi_summary(
             [
@@ -198,7 +198,7 @@ class TestAnalyzeExecutiveSummary:
                 ("Revenue at Risk (Dormant)", 5000.0),
             ]
         )
-        mock_revenue = AnalysisResult(name="Revenue Impact", title="test", df=revenue_kpis)
+        mock_revenue = AnalysisResult.from_df("Revenue Impact", "test", revenue_kpis)
 
         persona_df = pd.DataFrame(
             {
@@ -209,7 +209,7 @@ class TestAnalyzeExecutiveSummary:
                 "% of Total": [61.5, 38.5],
             }
         )
-        mock_personas = AnalysisResult(name="Activation Personas", title="test", df=persona_df)
+        mock_personas = AnalysisResult.from_df("Activation Personas", "test", persona_df)
 
         result = analyze_executive_summary(
             sample_df,

--- a/tests/ics/analysis/exports/test_kpi_slides.py
+++ b/tests/ics/analysis/exports/test_kpi_slides.py
@@ -19,10 +19,10 @@ def _exec_summary_result(hero_kpis=None, traffic_lights=None, narrative=None):
         metadata["traffic_lights"] = traffic_lights
     if narrative is not None:
         metadata["narrative"] = narrative
-    return AnalysisResult(
-        name="Executive Summary",
-        title="Executive Summary - Key ICS Metrics",
-        df=pd.DataFrame({"Metric": ["A"], "Value": [1]}),
+    return AnalysisResult.from_df(
+        "Executive Summary",
+        "Executive Summary - Key ICS Metrics",
+        pd.DataFrame({"Metric": ["A"], "Value": [1]}),
         metadata=metadata,
     )
 
@@ -101,18 +101,18 @@ class TestBuildNarrativeSlide:
 
 class TestGenerateDeclarativeTitle:
     def test_fallback_to_title(self):
-        result = AnalysisResult(
-            name="Unknown",
-            title="Some Title",
-            df=pd.DataFrame({"x": [1]}),
+        result = AnalysisResult.from_df(
+            "Unknown",
+            "Some Title",
+            pd.DataFrame({"x": [1]}),
         )
         assert generate_declarative_title(result) == "Some Title"
 
     def test_empty_df_falls_back(self):
-        result = AnalysisResult(
-            name="Activation Funnel",
-            title="Activation Funnel",
-            df=pd.DataFrame(),
+        result = AnalysisResult.from_df(
+            "Activation Funnel",
+            "Activation Funnel",
+            pd.DataFrame(),
         )
         assert generate_declarative_title(result) == "Activation Funnel"
 
@@ -123,10 +123,10 @@ class TestGenerateDeclarativeTitle:
                 "Count": [1000, 600],
             }
         )
-        result = AnalysisResult(
-            name="Activation Funnel",
-            title="Activation Funnel",
-            df=df,
+        result = AnalysisResult.from_df(
+            "Activation Funnel",
+            "Activation Funnel",
+            df,
         )
         title = generate_declarative_title(result)
         assert "60%" in title
@@ -139,10 +139,10 @@ class TestGenerateDeclarativeTitle:
                 "Count": [50, 30, 20],
             }
         )
-        result = AnalysisResult(
-            name="Days to First Use",
-            title="Days to First Use",
-            df=df,
+        result = AnalysisResult.from_df(
+            "Days to First Use",
+            "Days to First Use",
+            df,
         )
         title = generate_declarative_title(result)
         assert "80%" in title
@@ -156,10 +156,10 @@ class TestGenerateDeclarativeTitle:
                 "% of Total": [60.0, 25.0, 15.0],
             }
         )
-        result = AnalysisResult(
-            name="Engagement Decay",
-            title="Engagement Decay",
-            df=df,
+        result = AnalysisResult.from_df(
+            "Engagement Decay",
+            "Engagement Decay",
+            df,
         )
         title = generate_declarative_title(result)
         assert "25.0%" in title
@@ -173,10 +173,10 @@ class TestGenerateDeclarativeTitle:
                 "Spend Share %": [65.0, 80.0, 95.0],
             }
         )
-        result = AnalysisResult(
-            name="Spend Concentration",
-            title="Spend Concentration",
-            df=df,
+        result = AnalysisResult.from_df(
+            "Spend Concentration",
+            "Spend Concentration",
+            df,
         )
         title = generate_declarative_title(result)
         assert "65%" in title
@@ -189,10 +189,10 @@ class TestGenerateDeclarativeTitle:
                 "Composite Score": [120.0, 95.0],
             }
         )
-        result = AnalysisResult(
-            name="Branch Performance Index",
-            title="Branch Performance Index",
-            df=df,
+        result = AnalysisResult.from_df(
+            "Branch Performance Index",
+            "Branch Performance Index",
+            df,
         )
         title = generate_declarative_title(result)
         assert "Branch A" in title

--- a/tests/ics/analysis/test_excel_report.py
+++ b/tests/ics/analysis/test_excel_report.py
@@ -11,10 +11,10 @@ from ics_toolkit.analysis.exports.excel import write_excel_report
 def mock_analyses():
     """Create simple mock analysis results."""
     return [
-        AnalysisResult(
-            name="Test Analysis 1",
-            title="Test Title 1",
-            df=pd.DataFrame(
+        AnalysisResult.from_df(
+            "Test Analysis 1",
+            "Test Title 1",
+            pd.DataFrame(
                 {
                     "Category": ["A", "B", "Total"],
                     "Count": [10, 20, 30],
@@ -23,10 +23,10 @@ def mock_analyses():
             ),
             sheet_name="01_Test",
         ),
-        AnalysisResult(
-            name="Test Analysis 2",
-            title="Test Title 2",
-            df=pd.DataFrame(
+        AnalysisResult.from_df(
+            "Test Analysis 2",
+            "Test Title 2",
+            pd.DataFrame(
                 {
                     "Metric": ["Total", "Rate"],
                     "Value": [100, "50.0%"],
@@ -71,16 +71,16 @@ class TestWriteExcelReport:
 
     def test_skips_errored_analyses(self, sample_settings, sample_df, tmp_path):
         analyses = [
-            AnalysisResult(
-                name="Good",
-                title="Good Analysis",
-                df=pd.DataFrame({"A": [1]}),
+            AnalysisResult.from_df(
+                "Good",
+                "Good Analysis",
+                pd.DataFrame({"A": [1]}),
                 sheet_name="Good",
             ),
-            AnalysisResult(
-                name="Bad",
-                title="Bad Analysis",
-                df=pd.DataFrame(),
+            AnalysisResult.from_df(
+                "Bad",
+                "Bad Analysis",
+                pd.DataFrame(),
                 error="Something broke",
             ),
         ]

--- a/tests/ics/analysis/test_pptx_report.py
+++ b/tests/ics/analysis/test_pptx_report.py
@@ -20,22 +20,22 @@ from ics_toolkit.analysis.exports.pptx import (
 def mock_analyses():
     """Create mock analysis results matching SECTION_MAP names."""
     return [
-        AnalysisResult(
-            name="Total ICS Accounts",
-            title="ICS Accounts - Total Dataset",
-            df=pd.DataFrame({"Branch": ["Main", "West", "Total"], "Count": [60, 40, 100]}),
+        AnalysisResult.from_df(
+            "Total ICS Accounts",
+            "ICS Accounts - Total Dataset",
+            pd.DataFrame({"Branch": ["Main", "West", "Total"], "Count": [60, 40, 100]}),
             sheet_name="01_Total",
         ),
-        AnalysisResult(
-            name="Open ICS Accounts",
-            title="ICS Accounts - Open Accounts",
-            df=pd.DataFrame({"Branch": ["Main", "Total"], "Count": [50, 50]}),
+        AnalysisResult.from_df(
+            "Open ICS Accounts",
+            "ICS Accounts - Open Accounts",
+            pd.DataFrame({"Branch": ["Main", "Total"], "Count": [50, 50]}),
             sheet_name="02_Open",
         ),
-        AnalysisResult(
-            name="Bad Analysis",
-            title="Failed",
-            df=pd.DataFrame(),
+        AnalysisResult.from_df(
+            "Bad Analysis",
+            "Failed",
+            pd.DataFrame(),
             error="Something broke",
         ),
     ]
@@ -139,15 +139,15 @@ class TestWritePptxReport:
     def test_includes_table_slides(self, sample_settings, tmp_path):
         """Each successful non-empty analysis should produce a table slide."""
         analyses = [
-            AnalysisResult(
-                name="Total ICS Accounts",
-                title="Total ICS Accounts",
-                df=pd.DataFrame({"Branch": ["Main"], "Count": [100]}),
+            AnalysisResult.from_df(
+                "Total ICS Accounts",
+                "Total ICS Accounts",
+                pd.DataFrame({"Branch": ["Main"], "Count": [100]}),
             ),
-            AnalysisResult(
-                name="ICS by Stat Code",
-                title="ICS by Stat Code",
-                df=pd.DataFrame({"Stat": ["O", "C"], "Count": [80, 20]}),
+            AnalysisResult.from_df(
+                "ICS by Stat Code",
+                "ICS by Stat Code",
+                pd.DataFrame({"Stat": ["O", "C"], "Count": [80, 20]}),
             ),
         ]
         path = tmp_path / "tables.pptx"
@@ -159,10 +159,10 @@ class TestWritePptxReport:
     def test_chart_pngs_add_slides(self, sample_settings, tmp_path):
         """Analyses with chart PNGs get an extra chart slide."""
         analyses = [
-            AnalysisResult(
-                name="Total ICS Accounts",
-                title="Total ICS Accounts",
-                df=pd.DataFrame({"Branch": ["Main"], "Count": [100]}),
+            AnalysisResult.from_df(
+                "Total ICS Accounts",
+                "Total ICS Accounts",
+                pd.DataFrame({"Branch": ["Main"], "Count": [100]}),
             ),
         ]
         pngs = {"Total ICS Accounts": _make_tiny_png()}
@@ -180,10 +180,10 @@ class TestWritePptxReport:
     def test_unmapped_analyses_included(self, sample_settings, tmp_path):
         """Analyses not in SECTION_MAP still appear in the deck."""
         analyses = [
-            AnalysisResult(
-                name="Custom Analysis XYZ",
-                title="Custom Analysis XYZ",
-                df=pd.DataFrame({"Metric": ["A"], "Value": [42]}),
+            AnalysisResult.from_df(
+                "Custom Analysis XYZ",
+                "Custom Analysis XYZ",
+                pd.DataFrame({"Metric": ["A"], "Value": [42]}),
             ),
         ]
         path = tmp_path / "unmapped.pptx"

--- a/tests/ics/referral/analyses/test_overview.py
+++ b/tests/ics/referral/analyses/test_overview.py
@@ -48,7 +48,7 @@ class TestAnalyzeOverview:
 
     def test_accepts_prior_results(self, referral_context):
         prior = [
-            AnalysisResult(name="dummy", title="dummy", df=pd.DataFrame()),
+            AnalysisResult.from_df("dummy", "dummy", pd.DataFrame()),
         ]
         result = analyze_overview(referral_context, prior_results=prior)
         assert isinstance(result, AnalysisResult)

--- a/tests/ics/referral/charts/test_referral_charts.py
+++ b/tests/ics/referral/charts/test_referral_charts.py
@@ -182,7 +182,7 @@ class TestChartCodeHealth:
 class TestCreateReferralCharts:
     def test_creates_charts_for_matching_analyses(self, top_referrers_df, chart_config):
         analyses = [
-            AnalysisResult(name="Top Referrers", title="Top Referrers", df=top_referrers_df),
+            AnalysisResult.from_df("Top Referrers", "Top Referrers", top_referrers_df),
         ]
         charts = create_referral_charts(analyses, chart_config)
         assert "Top Referrers" in charts
@@ -190,15 +190,18 @@ class TestCreateReferralCharts:
 
     def test_skips_empty_analyses(self, chart_config):
         analyses = [
-            AnalysisResult(name="Top Referrers", title="Top Referrers", df=pd.DataFrame()),
+            AnalysisResult.from_df("Top Referrers", "Top Referrers", pd.DataFrame()),
         ]
         charts = create_referral_charts(analyses, chart_config)
         assert "Top Referrers" not in charts
 
     def test_skips_errored_analyses(self, top_referrers_df, chart_config):
         analyses = [
-            AnalysisResult(
-                name="Top Referrers", title="Top Referrers", df=top_referrers_df, error="oops"
+            AnalysisResult.from_df(
+                "Top Referrers",
+                "Top Referrers",
+                top_referrers_df,
+                error="oops",
             ),
         ]
         charts = create_referral_charts(analyses, chart_config)
@@ -206,7 +209,7 @@ class TestCreateReferralCharts:
 
     def test_skips_unregistered_analyses(self, chart_config):
         analyses = [
-            AnalysisResult(name="Unknown Analysis", title="Unknown", df=pd.DataFrame({"a": [1]})),
+            AnalysisResult.from_df("Unknown Analysis", "Unknown", pd.DataFrame({"a": [1]})),
         ]
         charts = create_referral_charts(analyses, chart_config)
         assert len(charts) == 0

--- a/tests/ics/test_runner.py
+++ b/tests/ics/test_runner.py
@@ -18,10 +18,10 @@ class TestConvertResults:
         from ics_toolkit.analysis.analyses.base import AnalysisResult
         from ics_toolkit.runner import _convert_results
 
-        ar = AnalysisResult(
-            name="portfolio_overview",
-            title="Portfolio Overview",
-            df=pd.DataFrame({"metric": ["Total"], "value": [1000]}),
+        ar = AnalysisResult.from_df(
+            "portfolio_overview",
+            "Portfolio Overview",
+            pd.DataFrame({"metric": ["Total"], "value": [1000]}),
             sheet_name="Portfolio",
             metadata={"count": 50},
         )
@@ -37,7 +37,7 @@ class TestConvertResults:
         from ics_toolkit.analysis.analyses.base import AnalysisResult
         from ics_toolkit.runner import _convert_results
 
-        ar = AnalysisResult(name="failed_one", title="Failed", df=pd.DataFrame(), error="broke")
+        ar = AnalysisResult.from_df("failed_one", "Failed", pd.DataFrame(), error="broke")
         results = _convert_results([ar])
         assert "failed_one" not in results
 

--- a/tests/shared/test_helpers.py
+++ b/tests/shared/test_helpers.py
@@ -1,0 +1,46 @@
+"""Tests for shared.helpers module."""
+
+from shared.helpers import safe_percentage, safe_ratio
+
+
+class TestSafePercentage:
+    def test_normal(self):
+        assert safe_percentage(25, 100) == 25.0
+
+    def test_zero_denominator(self):
+        assert safe_percentage(10, 0) == 0.0
+
+    def test_nan_denominator(self):
+        assert safe_percentage(10, float("nan")) == 0.0
+
+    def test_rounds_to_two_decimals(self):
+        assert safe_percentage(1, 3) == 33.33
+
+    def test_zero_numerator(self):
+        assert safe_percentage(0, 100) == 0.0
+
+    def test_full_percentage(self):
+        assert safe_percentage(50, 50) == 100.0
+
+    def test_over_100(self):
+        assert safe_percentage(200, 100) == 200.0
+
+
+class TestSafeRatio:
+    def test_normal(self):
+        assert safe_ratio(25, 100) == 0.25
+
+    def test_zero_denominator(self):
+        assert safe_ratio(10, 0) == 0.0
+
+    def test_nan_denominator(self):
+        assert safe_ratio(10, float("nan")) == 0.0
+
+    def test_custom_decimals(self):
+        assert safe_ratio(1, 3, decimals=4) == 0.3333
+
+    def test_default_two_decimals(self):
+        assert safe_ratio(1, 3) == 0.33
+
+    def test_zero_numerator(self):
+        assert safe_ratio(0, 100) == 0.0

--- a/tests/shared/test_types.py
+++ b/tests/shared/test_types.py
@@ -12,8 +12,10 @@ class TestAnalysisResult:
     def test_create_with_name_only(self):
         r = AnalysisResult(name="test")
         assert r.name == "test"
+        assert r.title == ""
         assert r.data == {}
         assert r.charts == []
+        assert r.error is None
         assert r.summary == ""
         assert r.metadata == {}
 
@@ -21,14 +23,18 @@ class TestAnalysisResult:
         df = pd.DataFrame({"a": [1, 2]})
         r = AnalysisResult(
             name="full",
+            title="Full Test",
             data={"main": df},
             charts=[Path("chart.png")],
+            error=None,
             summary="A test result",
             metadata={"count": 42},
         )
         assert r.name == "full"
+        assert r.title == "Full Test"
         assert "main" in r.data
         assert len(r.charts) == 1
+        assert r.error is None
         assert r.summary == "A test result"
         assert r.metadata["count"] == 42
 
@@ -46,3 +52,71 @@ class TestAnalysisResult:
         r1 = AnalysisResult(name="a")
         r2 = AnalysisResult(name="b")
         assert r1.charts is not r2.charts
+
+
+class TestAnalysisResultProperties:
+    def test_success_true_when_no_error(self):
+        r = AnalysisResult(name="ok")
+        assert r.success is True
+
+    def test_success_false_when_error(self):
+        r = AnalysisResult(name="fail", error="something broke")
+        assert r.success is False
+
+    def test_df_returns_main_dataframe(self):
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        r = AnalysisResult(name="t", data={"main": df})
+        assert r.df.equals(df)
+
+    def test_df_returns_empty_when_no_main(self):
+        r = AnalysisResult(name="t", data={"other": pd.DataFrame({"a": [1]})})
+        assert r.df.empty
+
+    def test_df_returns_empty_when_no_data(self):
+        r = AnalysisResult(name="t")
+        assert r.df.empty
+
+    def test_sheet_name_from_metadata(self):
+        r = AnalysisResult(name="t", metadata={"sheet_name": "custom_sheet"})
+        assert r.sheet_name == "custom_sheet"
+
+    def test_sheet_name_derived_from_name(self):
+        r = AnalysisResult(name="top merchants by spend")
+        assert r.sheet_name == "top_merchants_by_spend"
+
+    def test_sheet_name_truncated_to_31(self):
+        r = AnalysisResult(name="a" * 50)
+        assert len(r.sheet_name) == 31
+
+
+class TestFromDf:
+    def test_basic(self):
+        df = pd.DataFrame({"a": [1]})
+        r = AnalysisResult.from_df("test", "Test Title", df)
+        assert r.name == "test"
+        assert r.title == "Test Title"
+        assert r.df.equals(df)
+        assert r.sheet_name == "test"
+        assert r.error is None
+
+    def test_with_sheet_name(self):
+        df = pd.DataFrame({"a": [1]})
+        r = AnalysisResult.from_df("test", "Test", df, sheet_name="my_sheet")
+        assert r.sheet_name == "my_sheet"
+
+    def test_with_error(self):
+        df = pd.DataFrame()
+        r = AnalysisResult.from_df("test", "Test", df, error="bad data")
+        assert r.error == "bad data"
+        assert r.success is False
+
+    def test_with_metadata(self):
+        df = pd.DataFrame({"a": [1]})
+        r = AnalysisResult.from_df("test", "Test", df, metadata={"extra": 42})
+        assert r.metadata["extra"] == 42
+        assert "sheet_name" in r.metadata
+
+    def test_none_df(self):
+        r = AnalysisResult.from_df("test", "Test", None)
+        assert r.data == {}
+        assert r.df.empty

--- a/tests/txn/test_charts.py
+++ b/tests/txn/test_charts.py
@@ -36,20 +36,20 @@ def spend_result() -> AnalysisResult:
             "pct_of_total_amount": [20.0, 15.0, 12.0, 10.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0],
         }
     )
-    return AnalysisResult(
-        name="top_merchants_by_spend",
-        title="Top Merchants by Spend",
-        df=df,
+    return AnalysisResult.from_df(
+        "top_merchants_by_spend",
+        "Top Merchants by Spend",
+        df,
         sheet_name="M1 Top Spend",
     )
 
 
 @pytest.fixture()
 def empty_result() -> AnalysisResult:
-    return AnalysisResult(
-        name="top_merchants_by_spend",
-        title="Top Merchants by Spend",
-        df=pd.DataFrame(),
+    return AnalysisResult.from_df(
+        "top_merchants_by_spend",
+        "Top Merchants by Spend",
+        pd.DataFrame(),
         sheet_name="M1 Top Spend",
     )
 
@@ -186,7 +186,7 @@ class TestTrendCharts:
                 "2025-09": [2, 1, 3, 4, 5],
             }
         )
-        return AnalysisResult(name="monthly_rank_tracking", title="Rank", df=df, sheet_name="M5A")
+        return AnalysisResult.from_df("monthly_rank_tracking", "Rank", df, sheet_name="M5A")
 
     @pytest.fixture()
     def growth_result(self):
@@ -196,9 +196,7 @@ class TestTrendCharts:
                 "spend_change_pct": [50.0, 30.0, 10.0, -5.0, -20.0, -40.0],
             }
         )
-        return AnalysisResult(
-            name="growth_leaders_decliners", title="Growth", df=df, sheet_name="M5B"
-        )
+        return AnalysisResult.from_df("growth_leaders_decliners", "Growth", df, sheet_name="M5B")
 
     @pytest.fixture()
     def cohort_result(self):
@@ -210,9 +208,7 @@ class TestTrendCharts:
                 "returning_merchants": [2, 4, 6],
             }
         )
-        return AnalysisResult(
-            name="new_vs_declining_merchants", title="Cohort", df=df, sheet_name="M5D"
-        )
+        return AnalysisResult.from_df("new_vs_declining_merchants", "Cohort", df, sheet_name="M5D")
 
     def test_rank_trajectory_fig(self, rank_result, chart_config):
         from txn_analysis.charts.trends import chart_rank_trajectory
@@ -245,7 +241,7 @@ class TestTrendCharts:
     def test_empty_rank_returns_empty(self, chart_config):
         from txn_analysis.charts.trends import chart_rank_trajectory
 
-        empty = AnalysisResult(name="x", title="x", df=pd.DataFrame(), sheet_name="x")
+        empty = AnalysisResult.from_df("x", "x", pd.DataFrame(), sheet_name="x")
         fig = chart_rank_trajectory(empty, chart_config)
         assert len(fig.data) == 0
 
@@ -265,9 +261,7 @@ class TestCompetitorCharts:
                 "threat_score": [80, 60, 45],
             }
         )
-        return AnalysisResult(
-            name="competitor_threat_assessment", title="Threat", df=df, sheet_name="M6"
-        )
+        return AnalysisResult.from_df("competitor_threat_assessment", "Threat", df, sheet_name="M6")
 
     def test_threat_scatter_fig(self, threat_result, chart_config):
         from txn_analysis.charts.competitor import chart_threat_scatter
@@ -287,7 +281,7 @@ class TestCompetitorCharts:
     def test_empty_threat_returns_empty(self, chart_config):
         from txn_analysis.charts.competitor import chart_threat_scatter
 
-        empty = AnalysisResult(name="x", title="x", df=pd.DataFrame(), sheet_name="x")
+        empty = AnalysisResult.from_df("x", "x", pd.DataFrame(), sheet_name="x")
         fig = chart_threat_scatter(empty, chart_config)
         assert len(fig.data) == 0
 
@@ -312,7 +306,7 @@ class TestScorecardBullets:
                 "format": ["", "$", "", "$"],
             }
         )
-        return AnalysisResult(name="portfolio_scorecard", title="Scorecard", df=df, sheet_name="M9")
+        return AnalysisResult.from_df("portfolio_scorecard", "Scorecard", df, sheet_name="M9")
 
     def test_returns_figure(self, scorecard_result, chart_config):
         from txn_analysis.charts.scorecard import chart_scorecard_bullets
@@ -331,7 +325,7 @@ class TestScorecardBullets:
     def test_empty_returns_empty(self, chart_config):
         from txn_analysis.charts.scorecard import chart_scorecard_bullets
 
-        empty = AnalysisResult(name="x", title="x", df=pd.DataFrame(), sheet_name="x")
+        empty = AnalysisResult.from_df("x", "x", pd.DataFrame(), sheet_name="x")
         fig = chart_scorecard_bullets(empty, chart_config)
         assert len(fig.data) == 0
 
@@ -347,7 +341,7 @@ class TestScorecardBullets:
                 "format": [""],
             }
         )
-        result = AnalysisResult(name="x", title="x", df=df, sheet_name="x")
+        result = AnalysisResult.from_df("x", "x", df, sheet_name="x")
         fig = chart_scorecard_bullets(result, chart_config)
         assert len(fig.data) == 0
 
@@ -366,7 +360,7 @@ class TestMCCChart:
                 "total_amount": [50000, 30000, 20000],
             }
         )
-        return AnalysisResult(name="mcc_by_accounts", title="MCC", df=df, sheet_name="M2")
+        return AnalysisResult.from_df("mcc_by_accounts", "MCC", df, sheet_name="M2")
 
     def test_mcc_comparison_fig(self, mcc_result, chart_config):
         from txn_analysis.charts.mcc import chart_mcc_comparison
@@ -403,8 +397,8 @@ class TestCreateCharts:
     def test_empty_results_produce_no_charts(self, chart_config):
         from txn_analysis.charts import create_charts
 
-        empty = AnalysisResult(
-            name="top_merchants_by_spend", title="x", df=pd.DataFrame(), sheet_name="x"
+        empty = AnalysisResult.from_df(
+            "top_merchants_by_spend", "x", pd.DataFrame(), sheet_name="x"
         )
         charts = create_charts([empty], chart_config)
         assert len(charts) == 0

--- a/tests/txn/test_excel_report.py
+++ b/tests/txn/test_excel_report.py
@@ -75,8 +75,8 @@ class TestWriteExcelReport:
             settings=settings,
             df=pd.DataFrame(),
             analyses=[
-                AnalysisResult(name="ok", title="OK", df=pd.DataFrame({"a": [1]}), sheet_name="OK"),
-                AnalysisResult(name="bad", title="Bad", df=pd.DataFrame(), error="boom"),
+                AnalysisResult.from_df("ok", "OK", pd.DataFrame({"a": [1]}), sheet_name="OK"),
+                AnalysisResult.from_df("bad", "Bad", pd.DataFrame(), error="boom"),
             ],
         )
         path = tmp_path / "test_report.xlsx"

--- a/tests/txn/test_runner.py
+++ b/tests/txn/test_runner.py
@@ -14,10 +14,10 @@ class TestConvertResults:
     def test_converts_successful(self):
         from txn_analysis.analyses.base import AnalysisResult
 
-        ar = AnalysisResult(
-            name="top_merchants_by_spend",
-            title="Top Merchants by Spend",
-            df=pd.DataFrame({"merchant": ["A"], "spend": [1000]}),
+        ar = AnalysisResult.from_df(
+            "top_merchants_by_spend",
+            "Top Merchants by Spend",
+            pd.DataFrame({"merchant": ["A"], "spend": [1000]}),
             sheet_name="TopSpend",
             metadata={"top_n": 50},
         )
@@ -35,10 +35,10 @@ class TestConvertResults:
     def test_skips_failed(self):
         from txn_analysis.analyses.base import AnalysisResult
 
-        ar = AnalysisResult(
-            name="failed_one",
-            title="Failed Analysis",
-            df=pd.DataFrame(),
+        ar = AnalysisResult.from_df(
+            "failed_one",
+            "Failed Analysis",
+            pd.DataFrame(),
             error="Something broke",
         )
         results = _convert_results([ar])


### PR DESCRIPTION
## Summary
- **Unified AnalysisResult**: Extended `shared.types.AnalysisResult` with `title`, `error`, convenience properties (`df`, `sheet_name`, `success`), and `from_df()` factory method
- **Migrated TXN** (46 constructor sites, 22 files) to shared AnalysisResult
- **Migrated ICS** (186 constructor sites, 30 files) to shared AnalysisResult
- **Deduplicated helpers**: `safe_percentage` + `safe_ratio` -> `shared.helpers` (ICS/TXN re-export for zero downstream import changes)
- **Housekeeping**: Closed stale Issue #14, updated CLAUDE.md + HANDOFF.md, deprecated 3 overlapping plans

## Architecture Decision
ARS keeps its internal `AnalysisResult` (different field structure: `slide_id`, `chart_path`, `excel_data`). The `runner.py` bridge converts at the boundary. Forcing migration would touch 33 files with no functional benefit.

**Result**: 1 canonical shared type (TXN, ICS, platform, orchestrator) + 1 ARS-internal type.

## Test plan
- [x] 2,344 tests passing (up from 2,318 -- added 26 new tests for shared types + helpers)
- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] TXN integration tests pass (6/6)
- [x] ICS integration tests pass (3/3)
- [x] ARS integration tests pass (3/3)

Generated with [Claude Code](https://claude.com/claude-code)