### PR TITLE
chore: archive standalone repos, migrate issues, enable CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
       - run: uv python install 3.12
       - run: uv sync --all-packages
       - run: uv run ruff check .
@@ -27,6 +28,7 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
       - run: uv python install 3.12
       - run: uv sync --all-packages
       - name: Run unit tests with coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,9 @@
 
 ### What needs attention
 - **Windows .bat validation**: `run.bat`, `dashboard.bat`, `run_batch.bat` need testing on Windows M: drive.
-- **Standalone repo archival**: `ars-pipeline`, `ars_analysis-jupyter`, `ics_toolkit`, `ics_append` are superseded by this monorepo.
 - **Real-data validation on Windows**: E2E done with synthetic data; needs real client ODD/ICS/TXN files from M: drive.
+- **Issue #24**: Network path FileNotFoundError when formatting on M: drive (xlsxwriter temp file issue)
+- **Issue #23**: Comprehensive competitor config with 3-tier matching (feature enhancement for M6)
 
 ---
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -18,7 +18,7 @@
 | Coverage | **94%** (CI floor 80%) |
 | Lint | Clean (ruff check + ruff format) |
 | Open PRs | 0 |
-| Open Issues | 0 |
+| Open Issues | 2 (#23 competitor config, #24 M: drive bug) |
 | Branches | `main` only (local + remote) |
 
 ### Recent Milestones
@@ -83,13 +83,13 @@ Settings (Pydantic) -> data_loader.load_data() -> run_all_analyses() -> export_o
 
 ### High Priority (when deploying)
 
+- **Issue #24**: Network path FileNotFoundError when formatting on M: drive (xlsxwriter temp file issue)
 - **Windows .bat validation**: `run.bat`, `dashboard.bat`, `run_batch.bat` need testing on Windows M: drive
 - **Real-data validation**: E2E done with synthetic data; needs real client ODD/ICS/TXN files from M: drive
 
 ### Medium Priority
 
-- **Standalone repo archival**: `ars-pipeline`, `ars_analysis-jupyter`, `ics_toolkit`, `ics_append` are superseded by this monorepo. Archive or make read-only.
-- **Migrate standalone issues**: txn-analysis #10 (config), txn-analysis #13 (competitor merge), ars-pipeline #10 (production file path bug)
+- **Issue #23**: Comprehensive competitor config with 3-tier matching (migrated from txn-analysis #10 + #13)
 - **Reg E Enhancement**: 5-sprint plan in `plans/feat-reg-e-enhancement.md`
 
 ### Low Priority
@@ -98,7 +98,12 @@ Settings (Pydantic) -> data_loader.load_data() -> run_all_analyses() -> export_o
 - **Chart formatting fixes**: Spine removal, positioning consistency
 - **Cross-pipeline dashboard**: Unified results viewer across ARS/TXN/ICS
 - **PPTX template system**: Branded deck generation
-- **CI caching**: `uv cache` in GitHub Actions for faster builds
+
+### Done (this session)
+
+- Standalone repos archived: `txn-analysis`, `ars-pipeline`, `ics_toolkit`, `ars_analysis-jupyter`
+- Standalone issues migrated: txn-analysis #10+#13 -> #23, ars-pipeline #10 -> #24
+- CI caching enabled via `astral-sh/setup-uv` `enable-cache: true`
 
 ---
 


### PR DESCRIPTION
## Summary
- **Archived 4 repos**: `txn-analysis`, `ars-pipeline`, `ics_toolkit`, `ars_analysis-jupyter` (all superseded by this monorepo)
- **Migrated 3 open issues** from standalone repos to monorepo:
  - txn-analysis #10 + #13 (competitor config) -> #23
  - ars-pipeline #10 (M: drive FileNotFoundError) -> #24
- **Enabled CI caching**: `astral-sh/setup-uv` `enable-cache: true` for faster builds
- Updated CLAUDE.md and HANDOFF.md to reflect current state

## Test plan
- [x] CI config change only adds caching (no behavioral change)
- [x] Docs updated with new issue numbers
- [x] Lint passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>