### PR TITLE
feat(txn): upgrade M6 competitor detection to 3-tier matching

### DIFF
--- a/packages/txn_analysis/src/txn_analysis/analyses/__init__.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/__init__.py
@@ -23,6 +23,7 @@ from txn_analysis.analyses.competitor_metrics import (
 )
 from txn_analysis.analyses.competitor_segment import analyze_competitor_segmentation
 from txn_analysis.analyses.competitor_threat import analyze_threat_assessment
+from txn_analysis.analyses.discover_unmatched_financial import analyze_unmatched_financial
 from txn_analysis.analyses.financial_services import (
     analyze_financial_services_detection,
     analyze_financial_services_summary,
@@ -103,6 +104,7 @@ ANALYSIS_REGISTRY: list[tuple[str, AnalysisFunc]] = [
     ("competitor_monthly_trends", analyze_competitor_monthly_trends),
     ("competitor_threat_assessment", analyze_threat_assessment),
     ("competitor_segmentation", analyze_competitor_segmentation),
+    ("unmatched_financial", analyze_unmatched_financial),  # M6B-7
     # M7: Financial Services (detection before summary)
     ("financial_services_detection", analyze_financial_services_detection),
     ("financial_services_summary", analyze_financial_services_summary),

--- a/packages/txn_analysis/src/txn_analysis/analyses/competitor_detect.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/competitor_detect.py
@@ -1,11 +1,16 @@
-"""M6A: Competitor detection -- scans merchant names for competitor patterns."""
+"""M6A: Competitor detection -- 3-tier precision matching.
+
+Classifies merchant names via exact > starts_with > contains matching,
+with false-positive exclusion. Populates shared context for downstream
+M6B analyses.
+"""
 
 from __future__ import annotations
 
 import pandas as pd
 
 from txn_analysis.analyses.base import AnalysisResult
-from txn_analysis.competitor_patterns import COMPETITOR_MERCHANTS
+from txn_analysis.competitor_patterns import classify_merchant, is_false_positive
 from txn_analysis.settings import Settings
 
 
@@ -16,39 +21,62 @@ def analyze_competitor_detection(
     settings: Settings,
     context: dict | None = None,
 ) -> AnalysisResult:
-    """Detect competitor transactions and populate shared context."""
+    """Detect competitor transactions via 3-tier matching and populate shared context."""
     has_consolidated = "merchant_consolidated" in df.columns
     search_col = "merchant_consolidated" if has_consolidated else "merchant_name"
     upper_col = df[search_col].str.upper()
 
-    all_competitor_data: dict[str, pd.DataFrame] = {}
-    summary_rows: list[dict] = []
+    # Classify every merchant
+    classifications = upper_col.apply(classify_merchant)
+    categories = classifications.apply(lambda r: r.category)
+    tiers = classifications.apply(lambda r: r.tier)
+    patterns = classifications.apply(lambda r: r.pattern)
 
-    for category, patterns in COMPETITOR_MERCHANTS.items():
-        for pattern in patterns:
-            mask = upper_col.str.contains(pattern, case=False, na=False, regex=False)
-            matched = df[mask]
-            if matched.empty:
-                continue
-            comp_df = matched.copy()
-            comp_df["competitor_category"] = category
-            comp_df["competitor_name"] = pattern
-            all_competitor_data[pattern] = comp_df
-            summary_rows.append(
-                {
-                    "competitor": pattern,
-                    "category": category,
-                    "total_transactions": len(comp_df),
-                    "unique_accounts": comp_df["primary_account_num"].nunique(),
-                    "total_amount": round(comp_df["amount"].sum(), 2),
-                }
-            )
+    # Filter: matched AND not a false positive
+    matched_mask = categories.notna()
+    fp_mask = upper_col.apply(is_false_positive)
+    final_mask = matched_mask & ~fp_mask
+
+    if not final_mask.any():
+        empty_summary = pd.DataFrame()
+        if context is not None:
+            context["competitor_data"] = {}
+            context["competitor_summary"] = empty_summary
+        return AnalysisResult.from_df(
+            "competitor_detection",
+            "Competitor Detection",
+            empty_summary,
+            sheet_name="M6A Detection",
+        )
+
+    comp_df = df[final_mask].copy()
+    comp_df["competitor_category"] = categories[final_mask].values
+    comp_df["competitor_name"] = patterns[final_mask].values
+    comp_df["match_tier"] = tiers[final_mask].values
+
+    # Build per-pattern data dict (keyed by pattern for backward compat)
+    all_competitor_data: dict[str, pd.DataFrame] = {}
+    for pattern_name, group in comp_df.groupby("competitor_name"):
+        all_competitor_data[pattern_name] = group
+
+    # Build summary
+    summary_rows: list[dict] = []
+    for pattern_name, group in comp_df.groupby("competitor_name"):
+        summary_rows.append(
+            {
+                "competitor": pattern_name,
+                "category": group["competitor_category"].iloc[0],
+                "match_tier": group["match_tier"].iloc[0],
+                "total_transactions": len(group),
+                "unique_accounts": group["primary_account_num"].nunique(),
+                "total_amount": round(group["amount"].sum(), 2),
+            }
+        )
 
     summary_df = pd.DataFrame(summary_rows)
     if not summary_df.empty:
         summary_df = summary_df.sort_values("total_amount", ascending=False).reset_index(drop=True)
 
-    # Populate shared context for downstream M6B analyses
     if context is not None:
         context["competitor_data"] = all_competitor_data
         context["competitor_summary"] = summary_df

--- a/packages/txn_analysis/src/txn_analysis/analyses/discover_unmatched_financial.py
+++ b/packages/txn_analysis/src/txn_analysis/analyses/discover_unmatched_financial.py
@@ -1,0 +1,88 @@
+"""M6B-7: Discover unmatched financial-institution merchants.
+
+Finds merchants with financial MCC codes that are NOT already classified
+as competitors. Surfaces potential gaps in competitor pattern coverage.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from txn_analysis.analyses.base import AnalysisResult
+from txn_analysis.competitor_patterns import FINANCIAL_MCC_CODES
+from txn_analysis.settings import Settings
+
+
+def analyze_unmatched_financial(
+    df: pd.DataFrame,
+    business_df: pd.DataFrame,
+    personal_df: pd.DataFrame,
+    settings: Settings,
+    context: dict | None = None,
+) -> AnalysisResult:
+    """Find financial-MCC merchants not already classified as competitors."""
+    if "mcc_code" not in df.columns:
+        return _empty_result()
+
+    mcc_str = df["mcc_code"].astype(str).str.strip()
+    financial_mask = mcc_str.isin(FINANCIAL_MCC_CODES)
+    financial_df = df[financial_mask]
+
+    if financial_df.empty:
+        return _empty_result()
+
+    # Already-classified merchant names from M6A context
+    already_classified: set[str] = set()
+    if context:
+        comp_data = context.get("competitor_data", {})
+        for comp_df in comp_data.values():
+            search_col = (
+                "merchant_consolidated"
+                if "merchant_consolidated" in comp_df.columns
+                else "merchant_name"
+            )
+            already_classified.update(comp_df[search_col].str.upper().unique())
+
+    search_col = (
+        "merchant_consolidated" if "merchant_consolidated" in df.columns else "merchant_name"
+    )
+    upper_merchants = financial_df[search_col].str.upper()
+    unmatched_mask = ~upper_merchants.isin(already_classified)
+    unmatched = financial_df[unmatched_mask]
+
+    if unmatched.empty:
+        return _empty_result()
+
+    unmatched = unmatched.copy()
+    unmatched["_upper"] = unmatched[search_col].str.upper()
+
+    summary = (
+        unmatched.groupby("_upper")
+        .agg(
+            mcc_code=("mcc_code", "first"),
+            total_transactions=(search_col, "count"),
+            unique_accounts=("primary_account_num", "nunique"),
+            total_amount=("amount", "sum"),
+        )
+        .round(2)
+        .reset_index()
+        .rename(columns={"_upper": "merchant_name"})
+        .sort_values("total_amount", ascending=False)
+        .reset_index(drop=True)
+    )
+
+    return AnalysisResult.from_df(
+        "unmatched_financial",
+        "Unmatched Financial Merchants",
+        summary,
+        sheet_name="M6B-7 Unmatched",
+    )
+
+
+def _empty_result() -> AnalysisResult:
+    return AnalysisResult.from_df(
+        "unmatched_financial",
+        "Unmatched Financial Merchants",
+        pd.DataFrame(),
+        sheet_name="M6B-7 Unmatched",
+    )

--- a/packages/txn_analysis/src/txn_analysis/competitor_patterns.py
+++ b/packages/txn_analysis/src/txn_analysis/competitor_patterns.py
@@ -1,116 +1,439 @@
 """Competitor merchant patterns for M6 competitor analysis.
 
-Frozen module-level constant -- 6 categories of financial competitors.
+Three-tier precision matching: exact > starts_with > contains.
+Seven categories of financial competitors plus false-positive exclusions.
 """
 
 from __future__ import annotations
 
-COMPETITOR_MERCHANTS: dict[str, tuple[str, ...]] = {
-    "big_nationals": (
-        "JPMORGAN",
-        "CHASE",
-        "BANK OF AMERICA",
-        "WELLS FARGO",
-        "U.S. BANK",
-        "US BANK",
-        "PNC BANK",
-        "PNC",
-        "CITIBANK",
-        "CITI CARD",
-        "CAPITAL ONE",
-    ),
-    "regionals": (
-        "BMO",
-        "BMO HARRIS",
-        "FIFTH THIRD",
-        "5/3 BANK",
-        "HUNTINGTON",
-        "OLD NATIONAL",
-        "FIRST MIDWEST",
-        "WINTRUST",
-        "TOWN BANK",
-        "NORTH SHORE BANK",
-        "LAKE FOREST BANK",
-        "BYLINE BANK",
-        "FIRST AMERICAN BANK",
-        "ASSOCIATED BANK",
-        "CIBC BANK",
-        "MARQUETTE BANK",
-        "REPUBLIC BANK",
-        "FIRST MERCHANTS",
-        "PEOPLES BANK",
-        "PROVIDENCE BANK",
-    ),
-    "credit_unions": (
-        "ALLIANT CREDIT UNION",
-        "ALLIANT CU",
-        "CONSUMERS CREDIT UNION",
-        "BAXTER CREDIT UNION",
-        "BCU",
-        "CREDIT UNION 1",
-        "CU1",
-        "CORPORATE AMERICA FAMILY",
-        "CAFCU",
-        "FIRST NORTHERN CREDIT UNION",
-        "ABRI CREDIT UNION",
-        "NUMARK CREDIT UNION",
-        "EARTHMOVER CREDIT UNION",
-        "CHICAGO PATROLMEN",
-        "NORTHSTAR CREDIT UNION",
-        "UNITED CREDIT UNION",
-        "SELFRELIANCE",
-        "CHICAGO MUNICIPAL EMPLOYEES",
-    ),
-    "digital_banks": (
-        "ALLY BANK",
-        "DISCOVER BANK",
-        "CAPITAL ONE 360",
-        "SOFI BANK",
-        "SOFI MONEY",
-        "SOFI INVEST",
-        "CHIME",
-        "THE BANCORP",
-        "STRIDE BANK",
-        "VARO BANK",
-        "VARO MONEY",
-        "CURRENT CARD",
-        "CURRENT MOBILE",
-        "GO2BANK",
-        "GREEN DOT",
-        "REVOLUT",
-        "MARCUS BY GS",
-        "MARCUS SAVINGS",
-        "GOLDMAN SACHS",
-        "SCHWAB BANK",
-        "CHARLES SCHWAB",
-        "FIDELITY CASH",
-        "ROBINHOOD",
-        "BETTERMENT",
-        "WEALTHFRONT",
-    ),
-    "wallets_p2p": (
-        "PAYPAL",
-        "VENMO",
-        "CASH APP",
-        "SQ*",
-        "SUTTON",
-        "LINCOLN SAVINGS",
-        "APPLE CASH",
-        "APPLE CARD",
-        "GOOGLE PAY",
-    ),
-    "bnpl": (
-        "KLARNA",
-        "AFTERPAY",
-        "AFFIRM",
-        "ZIP PAY",
-        "ZIP CO",
-        "ZIP.CO",
-        "QUADPAY",
-        "SEZZLE",
-    ),
+from typing import NamedTuple
+
+MATCH_TIERS = ("exact", "starts_with", "contains")
+
+
+class MatchResult(NamedTuple):
+    """Result of classify_merchant()."""
+
+    category: str | None
+    tier: str | None
+    pattern: str | None
+
+
+COMPETITOR_MERCHANTS: dict[str, dict[str, tuple[str, ...]]] = {
+    "big_nationals": {
+        "exact": ("CHASE", "BOA", "KEYBANK", "SANTANDER", "CITI", "CITIZENS"),
+        "starts_with": (
+            "BANK OF AMERICA",
+            "BANKOFAMERICA",
+            "B OF A",
+            "BK OF AMERICA",
+            "BK OF AMER",
+            "WELLS FARGO",
+            "WELLSFARGO",
+            "WF BANK",
+            "WF HOME",
+            "CHASE BANK",
+            "CHASE BK",
+            "CHASE CREDIT",
+            "CHASE CARD",
+            "CHASE HOME",
+            "CHASE AUTO",
+            "CHASE MTG",
+            "JPMORGAN",
+            "JP MORGAN",
+            "CITIBANK",
+            "CITI BANK",
+            "CITI CARD",
+            "CITICORP",
+            "CITI MORTGAGE",
+            "CITIMORTGAGE",
+            "TD BANK",
+            "TD BK",
+            "TDBANK",
+            "TD BANKNORTH",
+            "CITIZENS BANK",
+            "CITIZENS BK",
+            "CITIZENS FINANCIAL",
+            "SANTANDER BANK",
+            "M&T BANK",
+            "M&T BK",
+            "M AND T BANK",
+            "M AND T BK",
+            "M & T BANK",
+            "MANUFACTURERS AND TRADERS",
+            "KEYBANK",
+            "KEY BANK",
+            "KEY BK",
+            "PNC BANK",
+            "PNC BK",
+            "US BANK",
+            "U.S. BANK",
+            "US BK",
+            "CAPITAL ONE",
+            "CAPITAL ONE BK",
+            "CAPITAL ONE BANK",
+            "CAPITAL ONE 360",
+            "CAP ONE BANK",
+            "CAPITALONE BK",
+        ),
+        "contains": (),
+    },
+    "regionals": {
+        "exact": ("BANKWELL",),
+        "starts_with": (
+            "WEBSTER BANK",
+            "WEBSTER BK",
+            "WEBSTERBANK",
+            "LIBERTY BANK",
+            "LIBERTY BK",
+            "ION BANK",
+            "ION BK",
+            "UNION SAVINGS",
+            "UNION SVG",
+            "NEWTOWN SAVINGS",
+            "NEWTOWN SVG",
+            "BEACON BANK",
+            "FAIRFIELD COUNTY BANK",
+            "FAIRFIELD COUNTY BK",
+            "FIRST COUNTY BANK",
+            "FIRST COUNTY BK",
+            "IVES BANK",
+            "IVES BK",
+            "THOMASTON SAVINGS",
+            "THOMASTON SVG",
+            "NORTHWEST COMMUNITY",
+            "NW COMMUNITY BANK",
+            "CHELSEA GROTON",
+            "ASCEND BANK",
+            "ASCEND BK",
+            "WINDSOR FEDERAL",
+            "GUILFORD SAVINGS",
+            "GUILFORD SVG",
+            "GSB BANK",
+            "ESSEX SAVINGS",
+            "ESSEX SVG",
+            "MILFORD BANK",
+            "THE MILFORD BANK",
+            "BANKWELL",
+            "PATRIOT BANK",
+            "PATRIOT BK",
+            "CENTREVILLE BANK",
+            "BANK OF NEW HAVEN",
+            "CONNECTICUT COMMUNITY",
+            "CT COMMUNITY BANK",
+            "PEOPLES BANK",
+            "PEOPLESBANK",
+            "PEOPLES BK",
+            "SAVINGS BANK OF DANBURY",
+            "BERKSHIRE BANK",
+            "BERKSHIRE BK",
+            "NBT BANK",
+            "NBT BK",
+            "DIME BANK",
+            "SI FINANCIAL",
+            "WASHINGTON TRUST",
+            "SAVINGS BANK OF WALPOLE",
+            "PEOPLES UNITED",
+            "FIRST NATIONAL BANK CT",
+            "PATRIOT NATIONAL",
+            # Midwest regionals (from original patterns)
+            "BMO",
+            "BMO HARRIS",
+            "FIFTH THIRD",
+            "5/3 BANK",
+            "HUNTINGTON",
+            "OLD NATIONAL",
+            "FIRST MIDWEST",
+            "WINTRUST",
+            "TOWN BANK",
+            "NORTH SHORE BANK",
+            "LAKE FOREST BANK",
+            "BYLINE BANK",
+            "FIRST AMERICAN BANK",
+            "ASSOCIATED BANK",
+            "CIBC BANK",
+            "MARQUETTE BANK",
+            "REPUBLIC BANK",
+            "FIRST MERCHANTS",
+            "PROVIDENCE BANK",
+        ),
+        "contains": (),
+    },
+    "credit_unions": {
+        "exact": (),
+        "starts_with": (
+            # CT credit unions
+            "NEW HAVEN COUNTY CREDIT",
+            "NEW HAVEN COUNTY CU",
+            "NHCCU",
+            "CROSSPOINT FEDERAL",
+            "CROSSPOINT FCU",
+            "CROSSPOINT CU",
+            "AFFINITY FEDERAL CU",
+            "AFFINITY FCU",
+            "AFFINITY CU",
+            "USALLIANCE FINANCIAL",
+            "USALLIANCE FED",
+            "USALLIANCE",
+            "GE CREDIT UNION",
+            "GE CU",
+            "SCIENT FEDERAL",
+            "SCIENT FCU",
+            "SCIENT CU",
+            "SCIENCE PARK FCU",
+            "SCIENCE PARK FED",
+            "MUTUAL SECURITY CU",
+            "MUTUAL SECURITY CREDIT",
+            "CT STATE EMPLOYEES CU",
+            "CONNECTICUT STATE EMPLOYEES",
+            "ACHIEVE FINANCIAL CU",
+            "ACHIEVE FINANCIAL CREDIT",
+            "NUTMEG STATE FINANCIAL",
+            "NUTMEG STATE CU",
+            "NUTMEG CU",
+            "NUTMEG STATE FCU",
+            "FINEX CREDIT UNION",
+            "FINEX CU",
+            "FINEX FCU",
+            "WESTERN CT FCU",
+            "WESTERN CONNECTICUT FCU",
+            "ISLAND FEDERAL CU",
+            "ISLAND FEDERAL CREDIT",
+            "AMERICAN EAGLE FCU",
+            "CHARTER OAK FCU",
+            "SIKORSKY FCU",
+            "TEACHERS FCU",
+            "YALE FEDERAL",
+            # National CUs
+            "NAVY FEDERAL",
+            "NAVY FED",
+            "NFCU",
+            "GOLDEN 1 CREDIT",
+            "GOLDEN 1 CU",
+            "PENTAGON FEDERAL",
+            "PENTAGON FCU",
+            "PENFED",
+            "STATE EMPLOYEES CU",
+            "USAA",
+            "ALLIANT CREDIT",
+            "ALLIANT CU",
+            "DIGITAL FCU",
+            # From original patterns
+            "CONSUMERS CREDIT UNION",
+            "BAXTER CREDIT UNION",
+            "BCU",
+            "CREDIT UNION 1",
+            "CU1",
+            "CORPORATE AMERICA FAMILY",
+            "CAFCU",
+            "FIRST NORTHERN CREDIT UNION",
+            "ABRI CREDIT UNION",
+            "NUMARK CREDIT UNION",
+            "EARTHMOVER CREDIT UNION",
+            "CHICAGO PATROLMEN",
+            "NORTHSTAR CREDIT UNION",
+            "UNITED CREDIT UNION",
+            "SELFRELIANCE",
+            "CHICAGO MUNICIPAL EMPLOYEES",
+        ),
+        "contains": (),
+    },
+    "digital_banks": {
+        "exact": ("CHIME", "REVOLUT", "BETTERMENT", "WEALTHFRONT", "SOFI", "ROBINHOOD", "MARCUS"),
+        "starts_with": (
+            "ALLY BANK",
+            "ALLY BK",
+            "ALLY FINANCIAL",
+            "DISCOVER BANK",
+            "DISCOVER BK",
+            "DISCOVER SAVINGS",
+            "SOFI BANK",
+            "SOFI MONEY",
+            "SOFI LENDING",
+            "SOFI CREDIT",
+            "SOFI INVEST",
+            "CHIME BANK",
+            "CHIME FINANCIAL",
+            "VARO BANK",
+            "VARO MONEY",
+            "GO2BANK",
+            "GREEN DOT BANK",
+            "GREEN DOT BK",
+            "GREENDOT",
+            "THE BANCORP",
+            "BANCORP BANK",
+            "STRIDE BANK",
+            "CURRENT CARD",
+            "CURRENT MOBILE",
+            "MARCUS BY GS",
+            "MARCUS BY GOLDMAN",
+            "MARCUS GOLDMAN",
+            "MARCUS SAVINGS",
+            "GOLDMAN SACHS BANK",
+            "SCHWAB BANK",
+            "CHARLES SCHWAB BK",
+            "SCHWAB BK",
+            "CHARLES SCHWAB",
+            "FIDELITY CASH",
+            "FIDELITY BROKERAGE",
+            "ROBINHOOD CASH",
+            "ROBINHOOD MONEY",
+            "CAPITAL ONE 360",
+            "REVOLUT",
+            "N26 BANK",
+            "N26",
+            "DAVE INC",
+            "DAVE APP",
+            "EARNIN",
+            "BRIGIT",
+            "POSSIBLE FINANCE",
+        ),
+        "contains": (
+            "CHIME",
+            "VARO",
+            "GREEN DOT",
+            "SYNCHRONY",
+        ),
+    },
+    "wallets_p2p": {
+        "exact": ("PAYPAL", "VENMO"),
+        "starts_with": (
+            "PAYPAL",
+            "VENMO",
+            "CASH APP",
+            "CASHAPP",
+            "APPLE CASH",
+            "APPLE CARD",
+            "APPLE PAY CASH",
+            "GOOGLE PAY",
+            "GOOGLEPAY",
+            "ZELLE",
+            "SQ *",
+        ),
+        "contains": (
+            "PAYPAL",
+            "VENMO",
+            "CASH APP",
+            "CASHAPP",
+            "APPLE CASH",
+            "GOOGLE PAY",
+            "ZELLE",
+        ),
+    },
+    "bnpl": {
+        "exact": ("KLARNA", "AFTERPAY", "SEZZLE"),
+        "starts_with": (
+            "KLARNA",
+            "AFTERPAY",
+            "AFFIRM",
+            "AFFIRM INC",
+            "SEZZLE",
+            "QUADPAY",
+            "ZIP PAY",
+            "ZIPPAY",
+            "ZIP CO",
+            "ZIP.CO",
+        ),
+        "contains": (
+            "AFTERPAY",
+            "KLARNA",
+            "AFFIRM",
+            "SEZZLE",
+            "QUADPAY",
+        ),
+    },
+    "alt_finance": {
+        "exact": (),
+        "starts_with": (
+            "FLEX FINANCE",
+            "FLEXFINANCE",
+            "MONEYLION",
+            "ALBERT SAVINGS",
+            "EMPOWER FINANCE",
+        ),
+        "contains": (),
+    },
 }
 
+
+FALSE_POSITIVES: tuple[str, ...] = (
+    "TOWING",
+    "TOW SERVICE",
+    "BODY SHOP",
+    "AUTO REPAIR",
+    "AUTO PARTS",
+    "AUTOZONE",
+    "AUTO TRADER",
+    "TRADER JOE",
+    "CHASE OUTDOORS",
+    "CURRENT ELECTRIC",
+)
+
+
+FINANCIAL_MCC_CODES: tuple[str, ...] = (
+    "6010",
+    "6011",
+    "6012",
+    "6050",
+    "6051",
+    "6211",
+    "6300",
+    "6399",
+    "6513",
+)
+
+
+# Pre-built exact-match lookup sets (computed once at import)
+_EXACT_LOOKUP: dict[str, frozenset[str]] = {
+    category: frozenset(tiers.get("exact", ())) for category, tiers in COMPETITOR_MERCHANTS.items()
+}
+
+# All exact patterns merged for fast O(1) first-pass lookup
+_ALL_EXACT: dict[str, str] = {}
+for _cat, _tiers in COMPETITOR_MERCHANTS.items():
+    for _pat in _tiers.get("exact", ()):
+        if _pat not in _ALL_EXACT:
+            _ALL_EXACT[_pat] = _cat
+
+
+def classify_merchant(merchant_name: str) -> MatchResult:
+    """Classify a merchant name via 3-tier matching.
+
+    Priority: exact > starts_with > contains. Returns on first match.
+    Expects upper-cased input. Does NOT apply false-positive filtering.
+    """
+    name = merchant_name.strip()
+
+    # Tier 1: exact (O(1) dict lookup)
+    cat = _ALL_EXACT.get(name)
+    if cat is not None:
+        return MatchResult(cat, "exact", name)
+
+    # Tier 2: starts_with
+    for category, tiers in COMPETITOR_MERCHANTS.items():
+        for prefix in tiers.get("starts_with", ()):
+            if name.startswith(prefix):
+                return MatchResult(category, "starts_with", prefix)
+
+    # Tier 3: contains
+    for category, tiers in COMPETITOR_MERCHANTS.items():
+        for substr in tiers.get("contains", ()):
+            if substr in name:
+                return MatchResult(category, "contains", substr)
+
+    return MatchResult(None, None, None)
+
+
+def is_false_positive(merchant_name: str) -> bool:
+    """Check if a merchant name matches any false-positive pattern."""
+    name = merchant_name.strip()
+    return any(fp in name for fp in FALSE_POSITIVES)
+
+
+# Backward-compat: flattened tuple of all patterns across all tiers
 ALL_COMPETITOR_PATTERNS: tuple[str, ...] = tuple(
-    p for patterns in COMPETITOR_MERCHANTS.values() for p in patterns
+    p
+    for tiers in COMPETITOR_MERCHANTS.values()
+    for tier_patterns in tiers.values()
+    for p in tier_patterns
 )

--- a/tests/integration/test_cli_e2e.py
+++ b/tests/integration/test_cli_e2e.py
@@ -78,7 +78,7 @@ class TestTxnCli:
         out.mkdir()
         result = runner.invoke(app, [str(TXN_CSV), "--output-dir", str(out)])
         assert result.exit_code == 0
-        assert "35/35" in result.output or "analyses completed" in result.output
+        assert "36/36" in result.output or "analyses completed" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/txn/test_cli.py
+++ b/tests/txn/test_cli.py
@@ -39,4 +39,4 @@ class TestCLI:
 
     def test_analyses_count_in_output(self, sample_csv_path, tmp_path):
         result = runner.invoke(app, [str(sample_csv_path), "--output-dir", str(tmp_path)])
-        assert "35" in result.output
+        assert "36" in result.output

--- a/tests/txn/test_competitor_detect.py
+++ b/tests/txn/test_competitor_detect.py
@@ -1,0 +1,111 @@
+"""Tests for M6A competitor detection analysis with 3-tier matching."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from txn_analysis.analyses.competitor_detect import analyze_competitor_detection
+from txn_analysis.settings import Settings
+
+
+def _settings() -> Settings:
+    return Settings(output_dir="/tmp/test")
+
+
+def _make_df(merchants: list[str], amounts: list[float] | None = None) -> pd.DataFrame:
+    n = len(merchants)
+    if amounts is None:
+        amounts = [100.0] * n
+    return pd.DataFrame(
+        {
+            "merchant_name": merchants,
+            "amount": amounts,
+            "primary_account_num": [f"ACCT{i}" for i in range(n)],
+            "business_flag": ["No"] * n,
+        }
+    )
+
+
+class TestCompetitorDetection:
+    def test_detects_exact_match(self):
+        df = _make_df(["CHASE", "WALMART", "TARGET"])
+        ctx: dict = {}
+        result = analyze_competitor_detection(df, df, df, _settings(), ctx)
+        assert result.error is None
+        assert len(ctx["competitor_data"]) == 1
+
+    def test_detects_starts_with_match(self):
+        df = _make_df(["BANK OF AMERICA NA", "COSTCO"])
+        ctx: dict = {}
+        analyze_competitor_detection(df, df, df, _settings(), ctx)
+        assert len(ctx["competitor_data"]) == 1
+
+    def test_detects_contains_match(self):
+        df = _make_df(["PURCHASE AT SYNCHRONY STORE", "GROCERY STORE"])
+        ctx: dict = {}
+        analyze_competitor_detection(df, df, df, _settings(), ctx)
+        assert len(ctx["competitor_data"]) == 1
+
+    def test_false_positive_excluded(self):
+        df = _make_df(["CHASE OUTDOORS LLC", "CHASE BANK NA"])
+        ctx: dict = {}
+        analyze_competitor_detection(df, df, df, _settings(), ctx)
+        # CHASE OUTDOORS should be excluded by false positive filter
+        all_merchants = set()
+        for comp_df in ctx["competitor_data"].values():
+            all_merchants.update(comp_df["merchant_name"].str.upper())
+        assert "CHASE OUTDOORS LLC" not in all_merchants
+        assert len(ctx["competitor_data"]) >= 1
+
+    def test_no_competitors_returns_empty(self):
+        df = _make_df(["WALMART", "TARGET", "COSTCO"])
+        ctx: dict = {}
+        result = analyze_competitor_detection(df, df, df, _settings(), ctx)
+        assert result.error is None
+        assert ctx["competitor_summary"].empty
+        assert ctx["competitor_data"] == {}
+
+    def test_summary_has_expected_columns(self):
+        df = _make_df(["CHASE BANK NA", "ALLY BANK DEPOSIT"])
+        ctx: dict = {}
+        analyze_competitor_detection(df, df, df, _settings(), ctx)
+        summary = ctx["competitor_summary"]
+        expected = {
+            "competitor",
+            "category",
+            "match_tier",
+            "total_transactions",
+            "unique_accounts",
+            "total_amount",
+        }
+        assert expected.issubset(set(summary.columns))
+
+    def test_summary_sorted_by_amount_descending(self):
+        df = _make_df(
+            ["CHASE BANK NA", "ALLY BANK DEPOSIT", "VENMO PAYMENT"],
+            [500.0, 200.0, 1000.0],
+        )
+        ctx: dict = {}
+        analyze_competitor_detection(df, df, df, _settings(), ctx)
+        summary = ctx["competitor_summary"]
+        amounts = summary["total_amount"].tolist()
+        assert amounts == sorted(amounts, reverse=True)
+
+    def test_context_none_is_safe(self):
+        df = _make_df(["CHASE"])
+        result = analyze_competitor_detection(df, df, df, _settings(), None)
+        assert result.error is None
+
+    def test_uses_merchant_consolidated_when_available(self):
+        df = _make_df(["ORIGINAL NAME"])
+        df["merchant_consolidated"] = ["CHASE BANK NA"]
+        ctx: dict = {}
+        analyze_competitor_detection(df, df, df, _settings(), ctx)
+        assert len(ctx["competitor_data"]) >= 1
+
+    def test_match_tier_in_context_data(self):
+        df = _make_df(["CHASE", "BANK OF AMERICA NA"])
+        ctx: dict = {}
+        analyze_competitor_detection(df, df, df, _settings(), ctx)
+        for comp_df in ctx["competitor_data"].values():
+            assert "match_tier" in comp_df.columns

--- a/tests/txn/test_competitor_patterns.py
+++ b/tests/txn/test_competitor_patterns.py
@@ -1,12 +1,21 @@
-"""Tests for txn_analysis.competitor_patterns."""
+"""Tests for txn_analysis.competitor_patterns -- 3-tier matching."""
 
 from __future__ import annotations
 
-from txn_analysis.competitor_patterns import ALL_COMPETITOR_PATTERNS, COMPETITOR_MERCHANTS
+from txn_analysis.competitor_patterns import (
+    ALL_COMPETITOR_PATTERNS,
+    COMPETITOR_MERCHANTS,
+    FALSE_POSITIVES,
+    FINANCIAL_MCC_CODES,
+    MATCH_TIERS,
+    MatchResult,
+    classify_merchant,
+    is_false_positive,
+)
 
 
 class TestCompetitorMerchants:
-    def test_six_categories(self):
+    def test_seven_categories(self):
         assert set(COMPETITOR_MERCHANTS.keys()) == {
             "big_nationals",
             "regionals",
@@ -14,22 +23,30 @@ class TestCompetitorMerchants:
             "digital_banks",
             "wallets_p2p",
             "bnpl",
+            "alt_finance",
         }
 
-    def test_big_nationals_non_empty(self):
-        assert len(COMPETITOR_MERCHANTS["big_nationals"]) >= 10
+    def test_each_category_has_valid_tier_keys(self):
+        for cat, tiers in COMPETITOR_MERCHANTS.items():
+            assert isinstance(tiers, dict), f"{cat} should be a dict"
+            for tier in tiers:
+                assert tier in MATCH_TIERS, f"Unknown tier '{tier}' in {cat}"
 
     def test_values_are_tuples(self):
-        for cat, patterns in COMPETITOR_MERCHANTS.items():
-            assert isinstance(patterns, tuple), f"{cat} values should be tuples"
+        for cat, tiers in COMPETITOR_MERCHANTS.items():
+            for tier_name, patterns in tiers.items():
+                assert isinstance(patterns, tuple), f"{cat}.{tier_name} should be tuple"
 
     def test_no_empty_patterns(self):
-        for cat, patterns in COMPETITOR_MERCHANTS.items():
-            for p in patterns:
-                assert p.strip(), f"Empty pattern in {cat}"
+        for cat, tiers in COMPETITOR_MERCHANTS.items():
+            for tier_name, patterns in tiers.items():
+                for p in patterns:
+                    assert p.strip(), f"Empty pattern in {cat}.{tier_name}"
 
     def test_all_patterns_flattened(self):
-        total = sum(len(v) for v in COMPETITOR_MERCHANTS.values())
+        total = sum(
+            len(patterns) for tiers in COMPETITOR_MERCHANTS.values() for patterns in tiers.values()
+        )
         assert len(ALL_COMPETITOR_PATTERNS) == total
 
     def test_known_competitors_present(self):
@@ -39,3 +56,96 @@ class TestCompetitorMerchants:
         assert "VENMO" in all_upper
         assert "KLARNA" in all_upper
         assert "CHIME" in all_upper
+
+    def test_big_nationals_has_minimum_patterns(self):
+        bn = COMPETITOR_MERCHANTS["big_nationals"]
+        total = sum(len(v) for v in bn.values())
+        assert total >= 10
+
+    def test_alt_finance_category_exists(self):
+        assert "alt_finance" in COMPETITOR_MERCHANTS
+        af = COMPETITOR_MERCHANTS["alt_finance"]
+        total = sum(len(v) for v in af.values())
+        assert total >= 3
+
+
+class TestClassifyMerchant:
+    def test_exact_match(self):
+        result = classify_merchant("CHASE")
+        assert result == MatchResult("big_nationals", "exact", "CHASE")
+
+    def test_starts_with_match(self):
+        result = classify_merchant("BANK OF AMERICA NA 12345")
+        assert result.category == "big_nationals"
+        assert result.tier == "starts_with"
+        assert result.pattern == "BANK OF AMERICA"
+
+    def test_contains_match(self):
+        result = classify_merchant("PAYMENT TO VENMO USER")
+        assert result.category == "wallets_p2p"
+        assert result.tier in ("exact", "starts_with", "contains")
+
+    def test_no_match(self):
+        result = classify_merchant("WALMART STORE 1234")
+        assert result == MatchResult(None, None, None)
+
+    def test_exact_prioritized_over_starts_with(self):
+        # KEYBANK is in both exact and starts_with for big_nationals
+        result = classify_merchant("KEYBANK")
+        assert result.tier == "exact"
+
+    def test_starts_with_prioritized_over_contains(self):
+        # "ALLY BANK" is starts_with in digital_banks
+        result = classify_merchant("ALLY BANK DEPOSIT 123")
+        assert result.tier == "starts_with"
+
+    def test_digital_bank_contains(self):
+        result = classify_merchant("PURCHASE AT SYNCHRONY STORE")
+        assert result.category == "digital_banks"
+        assert result.tier == "contains"
+        assert result.pattern == "SYNCHRONY"
+
+    def test_bnpl_detection(self):
+        result = classify_merchant("KLARNA")
+        assert result.category == "bnpl"
+
+    def test_alt_finance_detection(self):
+        result = classify_merchant("MONEYLION ADVANCE")
+        assert result.category == "alt_finance"
+        assert result.tier == "starts_with"
+
+    def test_whitespace_stripped(self):
+        result = classify_merchant("  CHASE  ")
+        assert result.category == "big_nationals"
+
+
+class TestFalsePositives:
+    def test_is_tuple(self):
+        assert isinstance(FALSE_POSITIVES, tuple)
+
+    def test_known_false_positives(self):
+        assert "TOWING" in FALSE_POSITIVES
+        assert "CHASE OUTDOORS" in FALSE_POSITIVES
+        assert "CURRENT ELECTRIC" in FALSE_POSITIVES
+
+    def test_is_false_positive_matches(self):
+        assert is_false_positive("BOB'S TOWING SERVICE")
+        assert is_false_positive("CHASE OUTDOORS LLC")
+
+    def test_is_false_positive_rejects_valid(self):
+        assert not is_false_positive("CHASE BANK NA")
+        assert not is_false_positive("ALLY BANK")
+
+
+class TestFinancialMccCodes:
+    def test_is_tuple(self):
+        assert isinstance(FINANCIAL_MCC_CODES, tuple)
+
+    def test_has_core_codes(self):
+        assert "6011" in FINANCIAL_MCC_CODES
+        assert "6012" in FINANCIAL_MCC_CODES
+
+    def test_all_are_digit_strings(self):
+        for code in FINANCIAL_MCC_CODES:
+            assert isinstance(code, str)
+            assert code.isdigit()

--- a/tests/txn/test_discover_unmatched.py
+++ b/tests/txn/test_discover_unmatched.py
@@ -1,0 +1,77 @@
+"""Tests for M6B-7 discover unmatched financial merchants."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from txn_analysis.analyses.discover_unmatched_financial import analyze_unmatched_financial
+from txn_analysis.settings import Settings
+
+
+def _settings() -> Settings:
+    return Settings(output_dir="/tmp/test")
+
+
+def _make_df(
+    merchants: list[str],
+    mcc_codes: list[str] | None = None,
+    amounts: list[float] | None = None,
+) -> pd.DataFrame:
+    n = len(merchants)
+    return pd.DataFrame(
+        {
+            "merchant_name": merchants,
+            "mcc_code": mcc_codes or ["9999"] * n,
+            "amount": amounts or [100.0] * n,
+            "primary_account_num": [f"ACCT{i}" for i in range(n)],
+            "business_flag": ["No"] * n,
+        }
+    )
+
+
+class TestDiscoverUnmatchedFinancial:
+    def test_no_mcc_column_returns_empty(self):
+        df = pd.DataFrame({"merchant_name": ["SOME MERCHANT"], "amount": [100.0]})
+        result = analyze_unmatched_financial(df, df, df, _settings())
+        assert result.df.empty
+
+    def test_financial_mcc_not_in_competitors_found(self):
+        df = _make_df(["UNKNOWN FI CORP"], mcc_codes=["6011"])
+        result = analyze_unmatched_financial(df, df, df, _settings())
+        assert not result.df.empty
+        assert "UNKNOWN FI CORP" in result.df["merchant_name"].str.upper().values
+
+    def test_already_classified_excluded(self):
+        df = _make_df(["CHASE BANK NA"], mcc_codes=["6011"])
+        ctx = {
+            "competitor_data": {"CHASE BANK": pd.DataFrame({"merchant_name": ["CHASE BANK NA"]})}
+        }
+        result = analyze_unmatched_financial(df, df, df, _settings(), ctx)
+        assert result.df.empty
+
+    def test_non_financial_mcc_excluded(self):
+        df = _make_df(["RANDOM MERCHANT"], mcc_codes=["5411"])
+        result = analyze_unmatched_financial(df, df, df, _settings())
+        assert result.df.empty
+
+    def test_summary_columns(self):
+        df = _make_df(["NEW FI SERVICE"], mcc_codes=["6012"])
+        result = analyze_unmatched_financial(df, df, df, _settings())
+        expected = {
+            "merchant_name",
+            "mcc_code",
+            "total_transactions",
+            "unique_accounts",
+            "total_amount",
+        }
+        assert expected.issubset(set(result.df.columns))
+
+    def test_sorted_by_amount_descending(self):
+        df = _make_df(
+            ["FI ALPHA", "FI BETA", "FI GAMMA"],
+            mcc_codes=["6011", "6012", "6050"],
+            amounts=[100.0, 500.0, 200.0],
+        )
+        result = analyze_unmatched_financial(df, df, df, _settings())
+        amounts = result.df["total_amount"].tolist()
+        assert amounts == sorted(amounts, reverse=True)

--- a/tests/txn/test_pipeline.py
+++ b/tests/txn/test_pipeline.py
@@ -20,7 +20,7 @@ class TestRunPipeline:
 
     def test_has_analyses(self, pipeline_settings):
         result = run_pipeline(pipeline_settings)
-        assert len(result.analyses) == 35
+        assert len(result.analyses) == 36
 
     def test_all_analyses_succeed(self, pipeline_settings):
         result = run_pipeline(pipeline_settings)

--- a/tests/txn/test_storylines.py
+++ b/tests/txn/test_storylines.py
@@ -36,7 +36,7 @@ class TestStorylineAdapters:
     def test_registry_count(self):
         from txn_analysis.analyses import ANALYSIS_REGISTRY
 
-        assert len(ANALYSIS_REGISTRY) == 35
+        assert len(ANALYSIS_REGISTRY) == 36
 
     def test_scorecard_is_last(self):
         from txn_analysis.analyses import ANALYSIS_REGISTRY


### PR DESCRIPTION
## Summary

Closes #23. Upgrades M6 competitor detection from flat substring matching to 3-tier precision matching with false-positive filtering.

- **3-tier matching**: exact (O(1) dict lookup) > starts_with > contains, first match wins
- **7 categories**: big_nationals, regionals, credit_unions, digital_banks, wallets_p2p, bnpl, alt_finance (new)
- **False-positive exclusion**: post-filter removes CHASE OUTDOORS, TOWING, AUTO REPAIR, etc.
- **M6B-7 discovery**: new analysis surfaces financial-MCC merchants not yet classified as competitors
- **Backward compatible**: context["competitor_data"] shape unchanged, all M6B-1 through M6B-6 analyses untouched
- Pipeline now runs **36/36** analyses (up from 35)

## Changes

| File | Change |
|------|--------|
| `competitor_patterns.py` | Restructured to 3-tier dict, added classify_merchant(), is_false_positive(), MatchResult, FINANCIAL_MCC_CODES |
| `competitor_detect.py` | Rewritten to use classify_merchant() + false-positive post-filter |
| `discover_unmatched_financial.py` | New M6B-7 analysis |
| `analyses/__init__.py` | Register M6B-7 (36 total) |
| 4 test assertion files | 35 -> 36 count updates |
| 3 new test files | 41 new tests |

## Test plan

- [x] 25 tests for competitor_patterns (3-tier structure, classify_merchant, false positives, MCC codes)
- [x] 10 tests for competitor_detect (exact/starts_with/contains detection, false positive exclusion, context safety)
- [x] 6 tests for discover_unmatched_financial (no mcc column, financial found, already classified excluded, non-financial excluded)
- [x] Full TXN suite: 632 passed
- [x] Full monorepo suite: 2,393 passed
- [x] E2E smoke: 36/36 analyses completed
- [x] Ruff check + format clean

Generated with [Claude Code](https://claude.com/claude-code)