### PR TITLE
fix(ars): use openpyxl for network path compatibility

### DIFF
--- a/packages/ars_analysis/src/ars_analysis/pipeline/steps/format.py
+++ b/packages/ars_analysis/src/ars_analysis/pipeline/steps/format.py
@@ -318,7 +318,7 @@ def format_all(
                 df = format_odd(df)
                 out_name = odd_file.stem + "-formatted.xlsx"
                 local_out = tmp_dir / out_name
-                df.to_excel(local_out, index=False, engine="xlsxwriter")
+                df.to_excel(local_out, index=False, engine="openpyxl")
 
                 # Copy result to network destination
                 dest_dir = out_root / csm_name / full_month / client_dir.name


### PR DESCRIPTION
## Summary
- Switches `engine="xlsxwriter"` to `engine="openpyxl"` in format step
- xlsxwriter creates internal temp files that fail on UNC/network paths (M: drive)
- openpyxl writes directly -- no temp file issues

Fixes #24

## Test plan
- [x] 545 ARS tests pass
- [ ] Manual: run `ars format` from M: drive path