### PR TITLE
fix(platform): terminal output for pipeline lifecycle events

### DIFF
--- a/packages/platform_app/src/platform_app/app.py
+++ b/packages/platform_app/src/platform_app/app.py
@@ -39,6 +39,12 @@ if not any(
     _root.addHandler(_fh)
     _root.setLevel(logging.DEBUG)
 
+    # Terminal output -- INFO+ so pipelines are visible in the console
+    _sh = logging.StreamHandler()
+    _sh.setLevel(logging.INFO)
+    _sh.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    _root.addHandler(_sh)
+
     # Also capture uncaught exceptions to the log file
     def _exception_hook(exc_type, exc_value, exc_tb):
         logging.critical("Uncaught exception", exc_info=(exc_type, exc_value, exc_tb))

--- a/packages/platform_app/src/platform_app/pages/home.py
+++ b/packages/platform_app/src/platform_app/pages/home.py
@@ -1126,6 +1126,7 @@ for idx, product in enumerate(sorted(needed_products, key=lambda p: p.value)):
                 input_files["odd"] = Path(_local_oddd)
 
     _status_text.markdown(f"**{pipeline_name.upper()}** -- Starting pipeline...")
+    print(f"[{pipeline_name.upper()}] Starting...")
 
     step_t0 = time.time()
     try:
@@ -1147,6 +1148,7 @@ for idx, product in enumerate(sorted(needed_products, key=lambda p: p.value)):
             text=f"{pipeline_name.upper()} complete -- {len(results)} results in {_step_elapsed}s",
         )
         _status_text.empty()
+        print(f"[{pipeline_name.upper()}] Complete -- {len(results)} results ({_step_elapsed}s)")
         logger.info(
             "Pipeline %s complete: %d results in %.1fs", pipeline_name, len(results), _step_elapsed
         )
@@ -1162,6 +1164,7 @@ for idx, product in enumerate(sorted(needed_products, key=lambda p: p.value)):
         _status_text.error(_last_line)
         with st.expander("Full traceback", expanded=False):
             st.code(_tb_str, language="python")
+        print(f"[{pipeline_name.upper()}] FAILED ({_step_elapsed}s)")
         logger.error("Pipeline %s failed for client %s:\n%s", pipeline_name, client_id, _tb_str)
 
 total_elapsed = round(time.time() - t0, 1)

--- a/packages/txn_analysis/src/txn_analysis/data_loader.py
+++ b/packages/txn_analysis/src/txn_analysis/data_loader.py
@@ -492,7 +492,7 @@ def load_odd(settings: Settings) -> pd.DataFrame | None:
     odd_path = settings.odd_file
     logger.info("Loading ODD file: %s", odd_path.name)
     if odd_path.suffix.lower() == ".csv":
-        odd_df = pd.read_csv(odd_path)
+        odd_df = pd.read_csv(odd_path, low_memory=False)
     else:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning, module="openpyxl")


### PR DESCRIPTION
## Summary
- Add `StreamHandler(INFO)` to root logger in `app.py` so all pipeline log output reaches the terminal (was file-only)
- Add `print()` at pipeline start/complete/fail in `home.py` for guaranteed terminal visibility
- Add `low_memory=False` to ODD CSV read in `data_loader.py` to suppress DtypeWarning

## Root Cause
Root logger had a `FileHandler` but no `StreamHandler`. All `logger.info()` / `logger.error()` calls from every pipeline went to `logs/app.log` but never appeared in the terminal window. The only visible terminal output was the `DtypeWarning` from pandas (which bypasses logging via stderr).

## Expected Terminal Output After Fix
```
[ARS] Starting...
INFO ars_analysis.runner: Starting ARS v2 pipeline...
[ARS] Complete -- 20 results (12.3s)
[ICS] Starting...
INFO ics_toolkit.runner: ...
[ICS] Complete -- 37 results (8.1s)
[TXN] Starting...
INFO txn_analysis.runner: ...
[TXN] Complete -- 35 results (15.2s)
```

## Test plan
- [x] `ruff check` passes on all 3 modified files
- [x] 789 platform + txn tests pass
- [ ] Manual: Run Streamlit, execute ARS+ICS+TXN -- verify terminal shows all pipeline output

Closes #58