### PR TITLE
feat(ics): ICS secondary deck quality overhaul + per-section module decks

### DIFF
--- a/packages/ics_toolkit/src/ics_toolkit/analysis/charts/cohort.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/charts/cohort.py
@@ -254,7 +254,7 @@ def chart_growth_patterns(df: pd.DataFrame, config: ChartConfig) -> bytes:
 def chart_activation_personas(df: pd.DataFrame, config: ChartConfig) -> bytes:
     """Donut chart of activation persona distribution."""
     buf = BytesIO()
-    with chart_figure(figsize=(10, 10), save_path=buf) as (_fig, ax):
+    with chart_figure(figsize=(12, 7), save_path=buf) as (_fig, ax):
         colors = [
             PERSONA_COLORS.get(cat, PALETTE[i % len(PALETTE)])
             for i, cat in enumerate(df["Category"])
@@ -270,7 +270,7 @@ def chart_activation_personas(df: pd.DataFrame, config: ChartConfig) -> bytes:
         )
 
         # Center hole for donut
-        centre = ax.add_patch(
+        ax.add_patch(
             __import__("matplotlib.patches", fromlist=["Circle"]).Circle((0, 0), 0.35, fc="white")
         )
 
@@ -285,8 +285,7 @@ def chart_activation_personas(df: pd.DataFrame, config: ChartConfig) -> bytes:
         ax.legend(
             wedges,
             legend_labels,
-            loc="center left",
-            bbox_to_anchor=(0.85, 0.5),
+            loc="center right",
             fontsize=12,
             frameon=False,
         )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/charts/performance.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/charts/performance.py
@@ -76,7 +76,7 @@ def chart_branch_performance_index(df: pd.DataFrame, config: ChartConfig) -> byt
     buf = BytesIO()
     categories = ["Activation Index", "Swipes Index", "Spend Index", "Balance Index"]
 
-    with chart_figure(figsize=(10, 10), save_path=buf) as (fig, ax):
+    with chart_figure(figsize=(14, 8), save_path=buf) as (fig, ax):
         ax.remove()
         ax = fig.add_subplot(111, polar=True)
 
@@ -92,13 +92,13 @@ def chart_branch_performance_index(df: pd.DataFrame, config: ChartConfig) -> byt
             ax.fill(angles, values, color=color, alpha=0.1)
 
         ax.set_xticks(angles[:-1])
-        ax.set_xticklabels(categories, fontsize=13)
-        ax.set_title("Branch Performance Index", fontsize=22, fontweight="bold", pad=30)
-        ax.legend(loc="upper right", bbox_to_anchor=(1.3, 1.0), fontsize=11)
+        ax.set_xticklabels(categories, fontsize=16)
+        ax.set_title("Branch Performance Index", fontsize=24, fontweight="bold", pad=30)
+        ax.legend(loc="upper right", bbox_to_anchor=(1.25, 1.0), fontsize=13)
 
         max_val = max(200, df[categories].max().max() + 20) if not df.empty else 200
         ax.set_ylim(0, max_val)
-        ax.yaxis.set_tick_params(labelsize=11)
+        ax.yaxis.set_tick_params(labelsize=13)
 
     buf.seek(0)
     return buf.read()

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/charts/portfolio.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/charts/portfolio.py
@@ -55,47 +55,62 @@ def _align_dual_axis_zero(
 
 
 def chart_engagement_decay(df: pd.DataFrame, config: ChartConfig) -> bytes:
-    """Bar chart of engagement decay categories."""
+    """Horizontal bar of engagement decay categories with semantic colors."""
+    # Semantic color mapping: green=active, amber=late, orange=decayed, red=never
+    _DECAY_COLORS = {
+        "Active": GROWTH,
+        "Late Activator": "#F39C12",
+        "Decayed": DECAY,
+        "Never Active": CLOSURE,
+    }
+    _DECAY_DESCRIPTIONS = {
+        "Active": "Used card in last 3 months",
+        "Late Activator": "First use >90 days after open",
+        "Decayed": "Previously active, inactive >3 months",
+        "Never Active": "No card usage since account open",
+    }
+
     buf = BytesIO()
     with chart_figure(figsize=(14, 8), save_path=buf) as (_fig, ax):
-        # Color gradient: green for active, orange/red for decaying
-        n = len(df)
-        gradient = []
-        for i in range(n):
-            frac = i / max(n - 1, 1)
-            if frac < 0.33:
-                gradient.append(GROWTH)
-            elif frac < 0.66:
-                gradient.append(DECAY)
-            else:
-                gradient.append(CLOSURE)
+        data = df.copy()
+        n = len(data)
+        total = data["Count"].sum() or 1
 
-        bars = ax.bar(
-            df["Decay Category"],
-            df["Count"],
-            color=gradient,
+        colors = [_DECAY_COLORS.get(cat, NAVY) for cat in data["Decay Category"]]
+
+        bars = ax.barh(
+            range(n),
+            data["Count"],
+            color=colors,
             edgecolor=BAR_EDGE,
             linewidth=BAR_EDGE_WIDTH,
             alpha=BAR_ALPHA,
-            width=0.55,
+            height=0.6,
         )
+        ax.set_yticks(range(n))
+        ax.set_yticklabels(data["Decay Category"])
+        ax.invert_yaxis()
 
-        for bar, val in zip(bars, df["Count"]):
+        # Data labels: count + percentage of total
+        for bar, val, cat in zip(bars, data["Count"], data["Decay Category"]):
+            pct = val / total * 100
+            desc = _DECAY_DESCRIPTIONS.get(cat, "")
+            label = f"  {val:,}  ({pct:.1f}%)"
+            if desc:
+                label += f"  --  {desc}"
             ax.text(
-                bar.get_x() + bar.get_width() / 2,
-                bar.get_height(),
-                f"{val:,}",
-                ha="center",
-                va="bottom",
-                fontsize=DATA_LABEL_SIZE,
+                bar.get_width(),
+                bar.get_y() + bar.get_height() / 2,
+                label,
+                va="center",
+                ha="left",
+                fontsize=DATA_LABEL_SIZE - 1,
                 fontweight="bold",
-                color=NAVY,
             )
 
-        ax.set_xlabel("Engagement Category")
-        ax.set_ylabel("Account Count")
+        ax.set_xlabel("Account Count")
         ax.set_title("Engagement Decay Analysis")
-        ax.grid(axis="y", alpha=0.15, linestyle="--")
+        ax.grid(axis="x", alpha=0.15, linestyle="--")
         ax.set_axisbelow(True)
 
     buf.seek(0)
@@ -333,42 +348,50 @@ def chart_closure_by_account_age(df: pd.DataFrame, config: ChartConfig) -> bytes
 
 
 def chart_net_growth_by_source(df: pd.DataFrame, config: ChartConfig) -> bytes:
-    """Grouped bar chart of opens/closes/net by source."""
+    """Stacked bar chart of opens (positive) and closes (negative) by source."""
     buf = BytesIO()
     with chart_figure(save_path=buf) as (_fig, ax):
         data = df[df["Source"] != "Total"].copy() if "Source" in df.columns else df
         x = np.arange(len(data))
-        width = 0.25
+        width = 0.5
 
+        opens = pd.to_numeric(data["Opens"], errors="coerce").fillna(0)
+        closes = pd.to_numeric(data["Closes"], errors="coerce").fillna(0)
+        net = pd.to_numeric(data["Net"], errors="coerce").fillna(0)
+
+        # Opens as positive bars, Closes as negative bars (stacked diverging)
         ax.bar(
-            x - width,
-            data["Opens"],
+            x,
+            opens,
             width,
             label="Opens",
             color=GROWTH,
             edgecolor=BAR_EDGE,
             linewidth=BAR_EDGE_WIDTH,
+            alpha=0.85,
         )
         ax.bar(
             x,
-            data["Closes"],
+            -closes,
             width,
             label="Closes",
             color=CLOSURE,
             edgecolor=BAR_EDGE,
             linewidth=BAR_EDGE_WIDTH,
+            alpha=0.85,
         )
 
         # Net as diamond markers
-        ax.scatter(x + width, data["Net"], s=120, marker="D", color=NAVY, zorder=5, label="Net")
-        for xi, val in zip(x, data["Net"]):
+        ax.scatter(x, net, s=120, marker="D", color=NAVY, zorder=5, label="Net")
+        for xi, val in zip(x, net):
             ax.text(
-                xi + width,
+                xi,
                 val,
                 f" {int(val):+,}",
                 fontsize=DATA_LABEL_SIZE - 2,
                 fontweight="bold",
                 va="bottom",
+                ha="center",
                 color=NAVY,
             )
 

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/charts/source.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/charts/source.py
@@ -181,7 +181,7 @@ def chart_source_by_branch(df: pd.DataFrame, config: ChartConfig) -> bytes:
 def chart_account_type(df: pd.DataFrame, config: ChartConfig) -> bytes:
     """Donut chart of Personal vs Business ICS accounts."""
     buf = BytesIO()
-    with chart_figure(figsize=(10, 10), save_path=buf) as (_fig, ax):
+    with chart_figure(figsize=(12, 7), save_path=buf) as (_fig, ax):
         data = df[df["Business?"] != "Total"].copy()
         colors = [NAVY, TEAL][: len(data)]
 
@@ -206,8 +206,7 @@ def chart_account_type(df: pd.DataFrame, config: ChartConfig) -> bytes:
         ax.legend(
             wedges,
             legend_labels,
-            loc="center left",
-            bbox_to_anchor=(0.85, 0.5),
+            loc="center right",
             fontsize=13,
             frameon=False,
         )

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/charts/summary.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/charts/summary.py
@@ -12,8 +12,6 @@ from ics_toolkit.analysis.charts.style import (
     BAR_EDGE,
     BAR_EDGE_WIDTH,
     DATA_LABEL_SIZE,
-    LINE_WIDTH,
-    MARKER_SIZE,
     NAVY,
     TEAL,
 )
@@ -23,7 +21,7 @@ from ics_toolkit.settings import ChartConfig
 def chart_total_ics(df: pd.DataFrame, config: ChartConfig) -> bytes:
     """Donut chart of ICS vs Non-ICS accounts."""
     buf = BytesIO()
-    with chart_figure(figsize=(10, 10), save_path=buf) as (_fig, ax):
+    with chart_figure(figsize=(12, 7), save_path=buf) as (_fig, ax):
         data = df[df["Category"] != "Total Accounts"].copy()
         colors = [NAVY, TEAL][: len(data)]
 
@@ -50,8 +48,7 @@ def chart_total_ics(df: pd.DataFrame, config: ChartConfig) -> bytes:
         ax.legend(
             wedges,
             legend_labels,
-            loc="center left",
-            bbox_to_anchor=(0.85, 0.5),
+            loc="center right",
             fontsize=13,
             frameon=False,
         )
@@ -147,7 +144,7 @@ def chart_prod_code(df: pd.DataFrame, config: ChartConfig) -> bytes:
 def chart_debit_dist(df: pd.DataFrame, config: ChartConfig) -> bytes:
     """Donut chart of Debit Card distribution."""
     buf = BytesIO()
-    with chart_figure(figsize=(10, 10), save_path=buf) as (_fig, ax):
+    with chart_figure(figsize=(12, 7), save_path=buf) as (_fig, ax):
         data = df[df["Debit?"] != "Total"].copy()
         colors = [ACQUISITION, "#E74C3C"][: len(data)]
 
@@ -172,8 +169,7 @@ def chart_debit_dist(df: pd.DataFrame, config: ChartConfig) -> bytes:
         ax.legend(
             wedges,
             legend_labels,
-            loc="center left",
-            bbox_to_anchor=(0.85, 0.5),
+            loc="center right",
             fontsize=13,
             frameon=False,
         )
@@ -186,60 +182,84 @@ def chart_debit_dist(df: pd.DataFrame, config: ChartConfig) -> bytes:
 
 
 def chart_debit_by_prod(df: pd.DataFrame, config: ChartConfig) -> bytes:
-    """Grouped bar of Debit Yes/No by Product Code with % line."""
+    """Stacked bar of Debit Yes/No by Product Code."""
     buf = BytesIO()
-    with chart_figure(save_path=buf) as (fig, ax):
+    with chart_figure(save_path=buf) as (_fig, ax):
         data = df[df["Prod Code"] != "Total"].copy()
         x = np.arange(len(data))
-        width = 0.3
+        width = 0.5
 
-        if "Yes" in data.columns:
-            ax.bar(
-                x - width / 2,
-                data["Yes"],
-                width,
-                label="Debit Yes",
-                color=ACQUISITION,
-                edgecolor=BAR_EDGE,
-                linewidth=BAR_EDGE_WIDTH,
-            )
-        if "No" in data.columns:
-            ax.bar(
-                x + width / 2,
-                data["No"],
-                width,
-                label="Debit No",
-                color="#E74C3C",
-                edgecolor=BAR_EDGE,
-                linewidth=BAR_EDGE_WIDTH,
-                alpha=0.7,
-            )
+        yes_vals = pd.to_numeric(data.get("Yes", pd.Series(dtype=float)), errors="coerce").fillna(0)
+        no_vals = pd.to_numeric(data.get("No", pd.Series(dtype=float)), errors="coerce").fillna(0)
 
+        bars_yes = ax.bar(
+            x,
+            yes_vals,
+            width,
+            label="Debit Yes",
+            color=ACQUISITION,
+            edgecolor=BAR_EDGE,
+            linewidth=BAR_EDGE_WIDTH,
+        )
+        bars_no = ax.bar(
+            x,
+            no_vals,
+            width,
+            bottom=yes_vals,
+            label="Debit No",
+            color="#E74C3C",
+            edgecolor=BAR_EDGE,
+            linewidth=BAR_EDGE_WIDTH,
+            alpha=0.7,
+        )
+
+        # Data labels on each segment
+        for bar, val in zip(bars_yes, yes_vals):
+            if val > 0:
+                ax.text(
+                    bar.get_x() + bar.get_width() / 2,
+                    bar.get_height() / 2,
+                    f"{int(val):,}",
+                    ha="center",
+                    va="center",
+                    fontsize=DATA_LABEL_SIZE - 2,
+                    fontweight="bold",
+                    color="white",
+                )
+        for bar, val, bottom in zip(bars_no, no_vals, yes_vals):
+            if val > 0:
+                ax.text(
+                    bar.get_x() + bar.get_width() / 2,
+                    bottom + val / 2,
+                    f"{int(val):,}",
+                    ha="center",
+                    va="center",
+                    fontsize=DATA_LABEL_SIZE - 2,
+                    fontweight="bold",
+                    color="white",
+                )
+
+        # % with Debit annotation above each bar
         if "% with Debit" in data.columns:
-            ax2 = ax.twinx()
-            ax2.plot(
-                x,
-                data["% with Debit"],
-                color=NAVY,
-                marker="D",
-                markersize=MARKER_SIZE,
-                linewidth=LINE_WIDTH,
-                label="% with Debit",
-                zorder=5,
-            )
-            ax2.set_ylabel("% with Debit")
-            ax2.set_ylim(0, 1.15)
-            ax2.yaxis.set_major_formatter(lambda x, _: f"{x:.0%}")
-            ax2.grid(False)
-            lines1, labels1 = ax.get_legend_handles_labels()
-            lines2, labels2 = ax2.get_legend_handles_labels()
-            ax.legend(lines1 + lines2, labels1 + labels2, loc="upper right")
+            totals = yes_vals + no_vals
+            for xi, total, pct in zip(x, totals, data["% with Debit"]):
+                ax.text(
+                    xi,
+                    total,
+                    f" {pct:.1f}%",
+                    ha="center",
+                    va="bottom",
+                    fontsize=DATA_LABEL_SIZE - 1,
+                    fontweight="bold",
+                    color=NAVY,
+                )
 
         ax.set_xticks(x)
         ax.set_xticklabels(data["Prod Code"])
         ax.set_xlabel("Product Code")
         ax.set_ylabel("Count")
         ax.set_title("Debit Distribution by Product Code")
+        ax.legend(loc="upper right")
         ax.grid(axis="y", alpha=0.15, linestyle="--")
         ax.set_axisbelow(True)
 
@@ -273,7 +293,7 @@ def chart_debit_by_branch(df: pd.DataFrame, config: ChartConfig) -> bytes:
         ax.set_yticklabels(data["Branch"].astype(str))
 
         for bar, val in zip(bars, rates):
-            label = f"{val:.1%}" if isinstance(val, float) else str(val)
+            label = f"{val:.1f}%" if isinstance(val, (int, float)) else str(val)
             ax.text(
                 bar.get_width(),
                 bar.get_y() + bar.get_height() / 2,
@@ -286,7 +306,7 @@ def chart_debit_by_branch(df: pd.DataFrame, config: ChartConfig) -> bytes:
 
         ax.set_xlabel("% with Debit Card")
         ax.set_title("Debit Rate by Branch")
-        ax.xaxis.set_major_formatter(lambda x, _: f"{x:.0%}")
+        ax.xaxis.set_major_formatter(lambda x, _: f"{x:.0f}%")
         ax.grid(axis="x", alpha=0.15, linestyle="--")
         ax.set_axisbelow(True)
 

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/exports/pptx.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/exports/pptx.py
@@ -84,8 +84,8 @@ SECTION_MAP = {
         "ICS Penetration by Branch",
     ],
     "Portfolio Health": [
-        "Engagement Decay",
         "Net Portfolio Growth",
+        "Engagement Decay",
         "Spend Concentration",
         "Closure by Source",
         "Closure by Branch",
@@ -183,6 +183,11 @@ for _names in SECTION_MAP.values():
 
 # Strings that mark a row as a "total" row.
 _TOTAL_MARKERS = {"total", "grand total"}
+
+# Pairs of analyses to merge side-by-side (left, right, merged title).
+_SECTION_MERGE_PAIRS: list[tuple[str, str, str]] = [
+    ("Closure by Branch", "Closure by Account Age", "Closures: Branch vs Account Age"),
+]
 
 # =========================================================================
 # PRIMARY DECK: Storyline-driven layout
@@ -373,10 +378,16 @@ def write_ics_reports(
     analyses: list[AnalysisResult],
     chart_pngs: dict[str, bytes] | None = None,
     output_dir: Path | None = None,
-) -> tuple[Path, Path]:
-    """Generate both Primary (storyline) and Secondary (detail) PPTX decks.
+    per_section: bool = False,
+) -> tuple[Path, Path] | tuple[Path, Path, dict[str, Path]]:
+    """Generate Primary (storyline) and Secondary (detail) PPTX decks.
 
-    Returns (primary_path, secondary_path).
+    Args:
+        per_section: If True, also generate per-section module decks.
+
+    Returns:
+        (primary_path, secondary_path) or
+        (primary_path, secondary_path, section_paths) when per_section=True.
     """
     out = output_dir or settings.output_dir
     out.mkdir(parents=True, exist_ok=True)
@@ -399,6 +410,17 @@ def write_ics_reports(
         output_path=secondary_path,
         chart_pngs=chart_pngs,
     )
+
+    if per_section:
+        section_dir = out / "sections"
+        section_paths = write_pptx_per_section(
+            settings,
+            analyses,
+            output_dir=section_dir,
+            chart_pngs=chart_pngs,
+        )
+        return primary, secondary, section_paths
+
     return primary, secondary
 
 
@@ -506,10 +528,24 @@ def write_pptx_secondary(
         if not section_analyses:
             continue
 
-        _add_section_divider(prs, section_name)
+        _add_styled_section_divider(prs, section_name)
+
+        # Pairs to merge side-by-side instead of separate slides
+        _merged: set[str] = set()
+        for left_name, right_name, _merge_title in _SECTION_MERGE_PAIRS:
+            if left_name in pngs and right_name in pngs:
+                _merged.update({left_name, right_name})
 
         for name, analysis in section_analyses:
             _add_table_slide(prs, analysis)
+
+            # Emit merged chart slide for paired analyses
+            if name in _merged:
+                for left_name, right_name, merge_title in _SECTION_MERGE_PAIRS:
+                    if name == left_name and left_name in pngs and right_name in pngs:
+                        _add_merged_slide(prs, merge_title, pngs[left_name], pngs[right_name])
+                continue
+
             if name in pngs:
                 _add_chart_slide(prs, analysis.title, pngs[name])
 
@@ -529,6 +565,89 @@ def write_pptx_secondary(
         len(prs.slides),
     )
     return output_path
+
+
+def write_pptx_per_section(
+    settings: Settings,
+    analyses: list[AnalysisResult],
+    output_dir: Path | None = None,
+    chart_pngs: dict[str, bytes] | None = None,
+    sections: list[str] | None = None,
+) -> dict[str, Path]:
+    """Generate one PPTX deck per SECTION_MAP section.
+
+    Each deck contains a title slide, styled section divider, and the
+    table + chart slides for that section's analyses only.
+
+    Args:
+        settings: Analysis settings.
+        analyses: List of analysis results.
+        output_dir: Directory for output files.
+        chart_pngs: Optional dict of chart PNG bytes keyed by analysis name.
+        sections: Optional list of section names to generate.
+            If None, generates all sections that have data.
+
+    Returns:
+        Dict mapping section name to output file path.
+    """
+    out = output_dir or settings.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+
+    date_str = datetime.now().strftime("%Y%m%d")
+    client_id = settings.client_id or "unknown"
+
+    lookup = _build_analysis_lookup(analyses)
+    pngs = chart_pngs or {}
+
+    target_sections = sections or list(SECTION_MAP.keys())
+    results: dict[str, Path] = {}
+
+    for section_name in target_sections:
+        if section_name not in SECTION_MAP:
+            logger.warning("Unknown section: %s (skipping)", section_name)
+            continue
+
+        analysis_names = SECTION_MAP[section_name]
+        section_analyses = [(name, lookup[name]) for name in analysis_names if name in lookup]
+        if not section_analyses:
+            continue
+
+        # Sanitize section name for filename
+        safe_name = section_name.replace(" ", "_").replace("/", "-")
+        path = out / f"{client_id}_ICS_{safe_name}_{date_str}.pptx"
+
+        prs = _create_presentation(settings)
+        _add_title_slide(prs, settings, title_text=f"ICS Analysis -- {section_name}")
+        _add_styled_section_divider(prs, section_name)
+
+        # Merge pairs (same logic as secondary deck)
+        _merged: set[str] = set()
+        for left_name, right_name, _merge_title in _SECTION_MERGE_PAIRS:
+            if left_name in pngs and right_name in pngs:
+                _merged.update({left_name, right_name})
+
+        for name, analysis in section_analyses:
+            _add_table_slide(prs, analysis)
+
+            if name in _merged:
+                for left_name, right_name, merge_title in _SECTION_MERGE_PAIRS:
+                    if name == left_name and left_name in pngs and right_name in pngs:
+                        _add_merged_slide(prs, merge_title, pngs[left_name], pngs[right_name])
+                continue
+
+            if name in pngs:
+                _add_chart_slide(prs, analysis.title, pngs[name])
+
+        prs.save(str(path))
+        results[section_name] = path
+        logger.info(
+            "Section deck saved: %s (%d slides)",
+            path.name,
+            len(prs.slides),
+        )
+
+    logger.info("Generated %d section decks", len(results))
+    return results
 
 
 def write_pptx_report(
@@ -764,6 +883,13 @@ def _add_table_slide(prs: Presentation, analysis: AnalysisResult) -> None:
     df = analysis.df
     if df.empty:
         return
+
+    # Show most-recent month first for temporal tables
+    if "Month" in df.columns:
+        total_mask = df["Month"].astype(str).str.strip().str.lower().isin(_TOTAL_MARKERS)
+        total_rows = df[total_mask]
+        data_rows = df[~total_mask].iloc[::-1]
+        df = pd.concat([data_rows, total_rows], ignore_index=True)
 
     layout = _get_layout(prs, preferred=11, fallback=6)
     slide = prs.slides.add_slide(layout)

--- a/packages/ics_toolkit/src/ics_toolkit/analysis/pipeline.py
+++ b/packages/ics_toolkit/src/ics_toolkit/analysis/pipeline.py
@@ -160,8 +160,14 @@ def run_pipeline(
 def export_outputs(
     result: AnalysisPipelineResult,
     skip_charts: bool = False,
+    per_section: bool = False,
 ) -> list[Path]:
     """Export pipeline results to configured output formats.
+
+    Args:
+        result: Pipeline result containing analyses and chart PNGs.
+        skip_charts: If True, charts were skipped during pipeline run.
+        per_section: If True, also generate per-section module decks.
 
     Returns list of generated file paths.
     """
@@ -195,13 +201,24 @@ def export_outputs(
         try:
             from ics_toolkit.analysis.exports.pptx import write_ics_reports
 
-            logger.info("Writing PowerPoint reports (Primary + Secondary)...")
-            primary_path, secondary_path = write_ics_reports(
+            label = "Primary + Secondary"
+            if per_section:
+                label += " + Per-Section"
+            logger.info("Writing PowerPoint reports (%s)...", label)
+
+            reports = write_ics_reports(
                 settings,
                 result.analyses,
                 chart_pngs=result.chart_pngs,
                 output_dir=settings.output_dir,
+                per_section=per_section,
             )
+            if per_section:
+                primary_path, secondary_path, section_paths = reports
+                generated.extend(section_paths.values())
+            else:
+                primary_path, secondary_path = reports
+
             generated.append(primary_path)
             generated.append(secondary_path)
         except Exception as e:

--- a/packages/ics_toolkit/src/ics_toolkit/cli.py
+++ b/packages/ics_toolkit/src/ics_toolkit/cli.py
@@ -162,6 +162,9 @@ def analyze(
         None, "--ics-not-in-dump", help="Count of ICS accounts not in data dump."
     ),
     no_charts: bool = typer.Option(False, "--no-charts", help="Skip chart rendering (faster)."),
+    per_section: bool = typer.Option(
+        False, "--per-section", help="Also generate per-section module decks."
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging."),
 ) -> None:
     """Run ICS analysis and generate reports.
@@ -169,6 +172,7 @@ def analyze(
     Usage:
         python -m ics_toolkit analyze data/client_file.xlsx
         python -m ics_toolkit analyze --config config.yaml
+        python -m ics_toolkit analyze data/file.xlsx --per-section
     """
     _setup_logging(verbose)
     logger = logging.getLogger(__name__)
@@ -204,7 +208,9 @@ def analyze(
         successful = [a for a in result.analyses if a.error is None]
         logger.info("Analyses completed: %d/%d", len(successful), len(result.analyses))
 
-        generated = export_outputs(result, skip_charts=no_charts)
+        generated = export_outputs(
+            result, skip_charts=no_charts, per_section=per_section,
+        )
 
         if generated:
             logger.info("")

--- a/packages/ics_toolkit/src/ics_toolkit/runner.py
+++ b/packages/ics_toolkit/src/ics_toolkit/runner.py
@@ -40,8 +40,10 @@ def run_ics(ctx: PipelineContext) -> dict[str, SharedResult]:
         if ctx.progress_callback:
             ctx.progress_callback(f"[ICS {step}/{total}] {msg}")
 
+    per_section = (ctx.client_config or {}).get("per_section", False)
+
     result = run_pipeline(settings.analysis, on_progress=_progress_bridge)
-    export_outputs(result)
+    export_outputs(result, per_section=per_section)
     return _convert_results(result.analyses)
 
 

--- a/packages/platform_app/src/platform_app/pages/pipeline_ics.py
+++ b/packages/platform_app/src/platform_app/pages/pipeline_ics.py
@@ -83,6 +83,17 @@ if enable_referral:
         "Network Analysis, Temporal Velocity, Referrer Scorecard"
     )
 
+# Per-Section Decks
+st.divider()
+st.markdown("**Output Options**")
+per_section = st.toggle(
+    "Generate per-section module decks",
+    value=st.session_state.get(f"{PREFIX}_per_section", False),
+    key=f"_toggle_{PREFIX}_per_section",
+    help="Produce one PPTX per section (Summary, Portfolio Health, etc.) in addition to Primary + Secondary decks",
+)
+st.session_state[f"{PREFIX}_per_section"] = per_section
+
 # Output directory
 out_default = ""
 if ics_path and Path(ics_path).exists():
@@ -189,6 +200,8 @@ input_files: dict[str, Path] = {"ics": Path(ics_path)}
 client_config: dict = {"client_id": client_id}
 if selected:
     client_config["module_ids"] = sorted(selected)
+if per_section:
+    client_config["per_section"] = True
 
 t0 = time.time()
 pipeline_error: str | None = None

--- a/tests/ics/analysis/test_pptx_report.py
+++ b/tests/ics/analysis/test_pptx_report.py
@@ -12,6 +12,7 @@ from ics_toolkit.analysis.exports.pptx import (
     _is_total_row,
     _prepare_table_df,
     write_chart_catalog,
+    write_pptx_per_section,
     write_pptx_report,
 )
 
@@ -287,3 +288,146 @@ class TestWriteChartCatalog:
         assert "Section:" in combined
         assert "Function:" in combined
         assert "Source:" in combined
+
+
+class TestWritePptxPerSection:
+    """Tests for per-section module deck generation."""
+
+    @pytest.fixture
+    def summary_analyses(self):
+        """Analyses that belong to the Summary section."""
+        return [
+            AnalysisResult.from_df(
+                "Total ICS Accounts",
+                "Total ICS Accounts",
+                pd.DataFrame({"Category": ["ICS", "Non-ICS"], "Count": [30, 70]}),
+            ),
+            AnalysisResult.from_df(
+                "ICS by Stat Code",
+                "ICS by Stat Code",
+                pd.DataFrame({"Stat Code": ["O", "C"], "Count": [25, 5]}),
+            ),
+        ]
+
+    @pytest.fixture
+    def portfolio_analyses(self):
+        """Analyses that belong to the Portfolio Health section."""
+        return [
+            AnalysisResult.from_df(
+                "Net Portfolio Growth",
+                "Net Portfolio Growth",
+                pd.DataFrame({"Month": ["Jan26", "Feb26"], "Net": [10, 15]}),
+            ),
+            AnalysisResult.from_df(
+                "Engagement Decay",
+                "Engagement Decay",
+                pd.DataFrame({"Category": ["Active", "Decayed"], "Count": [20, 10]}),
+            ),
+        ]
+
+    def test_generates_one_file_per_section(
+        self, sample_settings, summary_analyses, portfolio_analyses, tmp_path,
+    ):
+        all_analyses = summary_analyses + portfolio_analyses
+        out = tmp_path / "sections"
+        result = write_pptx_per_section(sample_settings, all_analyses, output_dir=out)
+        assert "Summary" in result
+        assert "Portfolio Health" in result
+        assert len(result) == 2
+
+    def test_each_file_exists(
+        self, sample_settings, summary_analyses, portfolio_analyses, tmp_path,
+    ):
+        all_analyses = summary_analyses + portfolio_analyses
+        out = tmp_path / "sections"
+        result = write_pptx_per_section(sample_settings, all_analyses, output_dir=out)
+        for path in result.values():
+            assert path.exists()
+
+    def test_section_deck_has_correct_slides(
+        self, sample_settings, summary_analyses, tmp_path,
+    ):
+        out = tmp_path / "sections"
+        result = write_pptx_per_section(sample_settings, summary_analyses, output_dir=out)
+        prs = Presentation(str(result["Summary"]))
+        # Title + section divider + 2 table slides = 4
+        assert len(prs.slides) == 4
+
+    def test_section_deck_includes_charts(
+        self, sample_settings, summary_analyses, tmp_path,
+    ):
+        pngs = {"Total ICS Accounts": _make_tiny_png()}
+        out = tmp_path / "sections"
+        result = write_pptx_per_section(
+            sample_settings, summary_analyses, output_dir=out, chart_pngs=pngs,
+        )
+        prs = Presentation(str(result["Summary"]))
+        # Title + divider + table + chart + table = 5
+        assert len(prs.slides) == 5
+
+    def test_empty_sections_skipped(self, sample_settings, tmp_path):
+        analyses = [
+            AnalysisResult.from_df(
+                "Total ICS Accounts",
+                "Total ICS Accounts",
+                pd.DataFrame({"A": [1]}),
+            ),
+        ]
+        out = tmp_path / "sections"
+        result = write_pptx_per_section(sample_settings, analyses, output_dir=out)
+        assert "Summary" in result
+        assert "Demographics" not in result
+
+    def test_filter_specific_sections(
+        self, sample_settings, summary_analyses, portfolio_analyses, tmp_path,
+    ):
+        all_analyses = summary_analyses + portfolio_analyses
+        out = tmp_path / "sections"
+        result = write_pptx_per_section(
+            sample_settings, all_analyses, output_dir=out, sections=["Summary"],
+        )
+        assert "Summary" in result
+        assert "Portfolio Health" not in result
+
+    def test_unknown_section_skipped(self, sample_settings, summary_analyses, tmp_path):
+        out = tmp_path / "sections"
+        result = write_pptx_per_section(
+            sample_settings,
+            summary_analyses,
+            output_dir=out,
+            sections=["Nonexistent Section"],
+        )
+        assert len(result) == 0
+
+    def test_filename_contains_section_name(
+        self, sample_settings, summary_analyses, tmp_path,
+    ):
+        out = tmp_path / "sections"
+        result = write_pptx_per_section(sample_settings, summary_analyses, output_dir=out)
+        assert "Summary" in result["Summary"].name
+
+    def test_merge_pairs_work_within_section(self, sample_settings, tmp_path):
+        """Closure by Branch + Closure by Account Age should merge in Portfolio Health."""
+        analyses = [
+            AnalysisResult.from_df(
+                "Closure by Branch",
+                "Closure by Branch",
+                pd.DataFrame({"Branch": ["Main"], "Count": [5]}),
+            ),
+            AnalysisResult.from_df(
+                "Closure by Account Age",
+                "Closure by Account Age",
+                pd.DataFrame({"Age": ["1-2yr"], "Count": [3]}),
+            ),
+        ]
+        pngs = {
+            "Closure by Branch": _make_tiny_png(),
+            "Closure by Account Age": _make_tiny_png(),
+        }
+        out = tmp_path / "sections"
+        result = write_pptx_per_section(
+            sample_settings, analyses, output_dir=out, chart_pngs=pngs,
+        )
+        prs = Presentation(str(result["Portfolio Health"]))
+        # Title + divider + table(branch) + merged_chart + table(age) = 5
+        assert len(prs.slides) == 5


### PR DESCRIPTION
## Summary

- **12 deck quality fixes** from slide-by-slide review: donut distortion, percentage math bug, chart redesigns, section divider styling, table sort order, merged slides, reordering
- **Per-section module decks**: new `write_pptx_per_section()` generates one PPTX per analysis section (Summary, Portfolio Health, Demographics, etc.) so each can be reviewed and refined individually before recombining
- **UI toggle**: Streamlit ICS page has "Generate per-section module decks" toggle that produces section decks with zero additional pipeline runtime

## Changes

### Deck Quality (11 files, 460 additions)
| Fix | File | Issue |
|-----|------|-------|
| Donut aspect ratio (4 charts) | summary.py, source.py, cohort.py | Square PNGs squashed into landscape slides |
| Debit by Branch % bug | summary.py | `crosstab_summary()` stores *100 values; chart double-multiplied with `:.1%` |
| Debit by Product redesign | summary.py | Grouped bar + twinx -> stacked column with segment labels |
| Engagement Decay redesign | portfolio.py | Vertical bar -> horizontal bar with semantic colors + descriptions |
| Net Growth stacked | portfolio.py | Grouped bar -> diverging stacked (opens up, closes down) |
| Section dividers | pptx.py | Secondary deck now uses styled navy dividers |
| Portfolio Health reorder | pptx.py | Net Portfolio Growth moved to first position |
| Closure charts merged | pptx.py | Branch + Account Age side-by-side on one slide |
| Monthly table sort | pptx.py | Most recent month first, totals preserved at bottom |
| Branch Performance | performance.py | Landscape (14x8) + larger fonts |
| Merge pairs refactored | pptx.py | `_SECTION_MERGE_PAIRS` extracted to module-level constant |

### Per-Section Module Decks
| Layer | Change |
|-------|--------|
| `pptx.py` | `write_pptx_per_section()` -- one deck per section with merge pair support |
| `pipeline.py` | `export_outputs(per_section=True)` |
| `cli.py` | `--per-section` flag |
| `runner.py` | Reads `per_section` from `client_config` |
| `pipeline_ics.py` | UI toggle, passes through `client_config` |

## Test plan
- [x] 9 new per-section tests (filtering, merge pairs, empty sections, filenames)
- [x] 1,053 ICS + integration tests pass
- [x] ruff clean
- [ ] E2E smoke test with real client data on Windows M: drive
- [ ] Verify section decks open correctly in PowerPoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)